### PR TITLE
[Fix] Repository Hilt Error

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/di/RoomModule.kt
+++ b/app/src/main/java/com/and04/naturealbum/di/RoomModule.kt
@@ -1,7 +1,12 @@
 package com.and04.naturealbum.di
 
 import android.content.Context
+import com.and04.naturealbum.data.repository.DataRepository
+import com.and04.naturealbum.data.repository.DataRepositoryImpl
+import com.and04.naturealbum.data.room.AlbumDao
 import com.and04.naturealbum.data.room.AppDatabase
+import com.and04.naturealbum.data.room.LabelDao
+import com.and04.naturealbum.data.room.PhotoDetailDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -36,4 +41,12 @@ object RoomModule {
     fun providerPhotoDetailDao(
         database: AppDatabase
     ) = database.photoDetailDao()
+
+    @Singleton
+    @Provides
+    fun providerRepository(
+        labelDao: LabelDao,
+        albumDao: AlbumDao,
+        photoDetailDao: PhotoDetailDao
+    ): DataRepository = DataRepositoryImpl(labelDao, albumDao, photoDetailDao)
 }


### PR DESCRIPTION
## 오류
hilt cannot be provided without an @Provides-annotated method. 에러 발생

## 원인
@Inject 어노테이션으로 Repository를 ViewModel에서 가져오는 과정에서 모듈에 Repository가 없어서 발생

## 해결
모듈에 Repository 추가하여 해결