### PR TITLE
마이페이지 구현

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
@@ -151,7 +151,7 @@ fun NatureAlbumNavHost(
         }
 
         composable(NavigateDestination.MyPage.route) {
-            MyPageScreen()
+            MyPageScreen(navigateToHome = { navController.navigate(NavigateDestination.Home.route) })
         }
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/component/MyTopAppBar.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/MyTopAppBar.kt
@@ -13,7 +13,7 @@ import com.and04.naturealbum.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyTopAppBar(navigationIcon: @Composable () -> Unit = {}, onClick: () -> Unit = { }) {
+fun MyTopAppBar(navigationIcon: @Composable () -> Unit = { }, onClick: () -> Unit = { }) {
     TopAppBar(
         title = {
             Text(stringResource(R.string.app_name))

--- a/app/src/main/java/com/and04/naturealbum/ui/component/MyTopAppBar.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/MyTopAppBar.kt
@@ -13,10 +13,13 @@ import com.and04.naturealbum.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MyTopAppBar(onClick: () -> Unit = { }) {
+fun MyTopAppBar(navigationIcon: @Composable () -> Unit = {}, onClick: () -> Unit = { }) {
     TopAppBar(
         title = {
             Text(stringResource(R.string.app_name))
+        },
+        navigationIcon = {
+            navigationIcon()
         },
         actions = {
             IconButton(onClick = { onClick() }) {

--- a/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreen.kt
@@ -113,7 +113,7 @@ fun HomeScreen(
         )
     }
 
-    Scaffold(topBar = { MyTopAppBar(onNavigateToMyPage) }) { innerPadding ->
+    Scaffold(topBar = { MyTopAppBar(onClick = onNavigateToMyPage) }) { innerPadding ->
         Column(
             modifier = Modifier
                 .padding(innerPadding)

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -85,7 +85,7 @@ fun MyPageScreen(
 }
 
 @Composable
-fun UserProfileContent(uri: Uri? = null, email: String? = null) {
+private fun UserProfileContent(uri: Uri? = null, email: String? = null) {
     UserProfileImage(
         uri = uri?.toString() ?: "",
         modifier = Modifier
@@ -101,7 +101,7 @@ fun UserProfileContent(uri: Uri? = null, email: String? = null) {
 }
 
 @Composable
-fun UserProfileImage(uri: String?, modifier: Modifier) {
+private fun UserProfileImage(uri: String?, modifier: Modifier) {
     uri?.let {
         AsyncImage(
             model = uri,
@@ -117,7 +117,7 @@ fun UserProfileImage(uri: String?, modifier: Modifier) {
 }
 
 @Composable
-fun LoginContent(loginHandle: () -> Unit) {
+private fun LoginContent(loginHandle: () -> Unit) {
     Column(
         modifier = Modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -94,7 +94,7 @@ fun UserProfileContent(uri: Uri? = null, email: String? = null) {
     )
 
     Text(
-        text = email ?: "",
+        text = email ?: stringResource(R.string.my_page_default_user_email),
         modifier = Modifier.fillMaxWidth(),
         textAlign = TextAlign.Center
     )

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -30,21 +30,25 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.and04.naturealbum.R
 import com.and04.naturealbum.ui.component.MyTopAppBar
+import com.and04.naturealbum.ui.savephoto.UiState
 import com.and04.naturealbum.ui.theme.NatureAlbumTheme
 
 @Composable
 fun MyPageScreen(
-    myPageViewModel: MyPageViewModel = hiltViewModel()
+    myPageViewModel: MyPageViewModel = hiltViewModel(),
+    navigateToHome: () -> Unit
 ) {
     val context = LocalContext.current
+    val uiState = myPageViewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(topBar = {
         MyTopAppBar(
             navigationIcon = {
-                IconButton(onClick = { /* TODO */ }) {
+                IconButton(onClick = { navigateToHome() }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = stringResource(R.string.my_page_arrow_back_icon_content_description)
@@ -61,42 +65,24 @@ fun MyPageScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(32.dp)
         ) {
-            UserProfileContent("", "")
-            LoginContent({})
-        }
-    }
-}
+            when (uiState.value) {
+                is UiState.Success -> {
+                    val email = UserManager.getNotNullSignInUser().email
+                    UserProfileContent(email = email)
+                }
 
-@Composable
-fun MyPageScreen(dummyClick: () -> Unit) {
-    Scaffold(topBar = {
-        MyTopAppBar(
-            navigationIcon = {
-                IconButton(onClick = { /* TODO */ }) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(R.string.my_page_arrow_back_icon_content_description)
-                    )
+                else -> {
+                    UserProfileContent()
                 }
             }
-        )
-    }) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .padding(horizontal = 16.dp)
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(32.dp)
-        ) {
-            UserProfileContent("", "")
-            LoginContent({})
+
+            LoginContent({ myPageViewModel.signInWithGoogle(context) })
         }
     }
 }
 
 @Composable
-fun UserProfileContent(uri: String, email: String) {
+fun UserProfileContent(uri: String? = null, email: String? = null) {
     UserProfileImage(
         uri = uri,
         modifier = Modifier
@@ -105,27 +91,26 @@ fun UserProfileContent(uri: String, email: String) {
     )
 
     Text(
-        text = email.ifEmpty { stringResource(R.string.my_page_default_user_email) },
+        text = email ?: "",
         modifier = Modifier.fillMaxWidth(),
         textAlign = TextAlign.Center
     )
 }
 
 @Composable
-fun UserProfileImage(uri: String, modifier: Modifier) {
-    if (uri.isEmpty()) {
-        Image(
-            imageVector = Icons.Default.AccountCircle,
-            contentDescription = stringResource(R.string.my_page_user_profile_image),
-            modifier = modifier
-        )
-    } else {
+fun UserProfileImage(uri: String?, modifier: Modifier) {
+    uri?.let {
         AsyncImage(
             model = uri,
             contentDescription = stringResource(R.string.my_page_user_profile_image),
             modifier = modifier.clip(CircleShape)
         )
-    }
+    } ?: Image(
+        imageVector = Icons.Default.AccountCircle,
+        contentDescription = stringResource(R.string.my_page_user_profile_image),
+        modifier = modifier
+    )
+
 }
 
 @Composable
@@ -154,6 +139,6 @@ fun LoginContent(loginHandle: () -> Unit) {
 @Composable
 private fun MyPageScreenPreview() {
     NatureAlbumTheme {
-        MyPageScreen({})
+//        MyPageScreen({})
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -1,10 +1,39 @@
 package com.and04.naturealbum.ui.mypage
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil3.compose.AsyncImage
+import com.and04.naturealbum.R
+import com.and04.naturealbum.ui.component.MyTopAppBar
+import com.and04.naturealbum.ui.theme.NatureAlbumTheme
 
 @Composable
 fun MyPageScreen(
@@ -12,8 +41,119 @@ fun MyPageScreen(
 ) {
     val context = LocalContext.current
 
-    Button(onClick = {
-        myPageViewModel.signInWithGoogle(context)
+    Scaffold(topBar = {
+        MyTopAppBar(
+            navigationIcon = {
+                IconButton(onClick = { /* TODO */ }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.my_page_arrow_back_icon_content_description)
+                    )
+                }
+            }
+        )
+    }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            UserProfileContent("", "")
+            LoginContent({})
+        }
     }
-    ) { Text("Test Button") }
+}
+
+@Composable
+fun MyPageScreen(dummyClick: () -> Unit) {
+    Scaffold(topBar = {
+        MyTopAppBar(
+            navigationIcon = {
+                IconButton(onClick = { /* TODO */ }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.my_page_arrow_back_icon_content_description)
+                    )
+                }
+            }
+        )
+    }) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(32.dp)
+        ) {
+            UserProfileContent("", "")
+            LoginContent({})
+        }
+    }
+}
+
+@Composable
+fun UserProfileContent(uri: String, email: String) {
+    UserProfileImage(
+        uri = uri,
+        modifier = Modifier
+            .fillMaxHeight(0.2f)
+            .aspectRatio(1f)
+    )
+
+    Text(
+        text = email.ifEmpty { stringResource(R.string.my_page_default_user_email) },
+        modifier = Modifier.fillMaxWidth(),
+        textAlign = TextAlign.Center
+    )
+}
+
+@Composable
+fun UserProfileImage(uri: String, modifier: Modifier) {
+    if (uri.isEmpty()) {
+        Image(
+            imageVector = Icons.Default.AccountCircle,
+            contentDescription = stringResource(R.string.my_page_user_profile_image),
+            modifier = modifier
+        )
+    } else {
+        AsyncImage(
+            model = uri,
+            contentDescription = stringResource(R.string.my_page_user_profile_image),
+            modifier = modifier.clip(CircleShape)
+        )
+    }
+}
+
+@Composable
+fun LoginContent(loginHandle: () -> Unit) {
+    Column(
+        modifier = Modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.my_page_login_txt),
+            textAlign = TextAlign.Left
+        )
+
+        Button(
+            onClick = { loginHandle() },
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(30)
+        ) {
+            Text(text = stringResource(R.string.my_page_google_login_btn))
+        }
+    }
+}
+
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, uiMode = UI_MODE_NIGHT_NO)
+@Composable
+private fun MyPageScreenPreview() {
+    NatureAlbumTheme {
+        MyPageScreen({})
+    }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -40,8 +40,8 @@ import com.and04.naturealbum.ui.theme.NatureAlbumTheme
 
 @Composable
 fun MyPageScreen(
+    navigateToHome: () -> Unit,
     myPageViewModel: MyPageViewModel = hiltViewModel(),
-    navigateToHome: () -> Unit
 ) {
     val context = LocalContext.current
     val uiState = myPageViewModel.uiState.collectAsStateWithLifecycle()

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -67,7 +67,7 @@ fun MyPageScreen(
         ) {
             when (uiState.value) {
                 is UiState.Success -> {
-                    val email = UserManager.getNotNullSignInUser().email
+                    val email = UserManager.getUser()?.email
                     UserProfileContent(email = email)
                 }
 

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -2,6 +2,7 @@ package com.and04.naturealbum.ui.mypage
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -67,8 +68,10 @@ fun MyPageScreen(
         ) {
             when (uiState.value) {
                 is UiState.Success -> {
-                    val email = UserManager.getUser()?.email
-                    UserProfileContent(email = email)
+                    val user = UserManager.getUser()
+                    val email = user?.email
+                    val photoUri = user?.photoUrl
+                    UserProfileContent(uri = photoUri, email = email)
                 }
 
                 else -> {
@@ -82,9 +85,9 @@ fun MyPageScreen(
 }
 
 @Composable
-fun UserProfileContent(uri: String? = null, email: String? = null) {
+fun UserProfileContent(uri: Uri? = null, email: String? = null) {
     UserProfileImage(
-        uri = uri,
+        uri = uri?.toString() ?: "",
         modifier = Modifier
             .fillMaxHeight(0.2f)
             .aspectRatio(1f)

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageViewModel.kt
@@ -3,7 +3,10 @@ package com.and04.naturealbum.ui.mypage
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.and04.naturealbum.ui.savephoto.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
@@ -12,14 +15,24 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val authenticationManager: AuthenticationManager
 ) : ViewModel() {
+    private val _uiState = MutableStateFlow<UiState>(setInitUiState())
+    val uiState: StateFlow<UiState> = _uiState
 
     fun signInWithGoogle(context: Context) {
         authenticationManager.signInWithGoogle(context).onEach { response ->
             when (response) {
                 is AuthResponse.Success -> {
-                    val token = response.token // token
+                    _uiState.emit(UiState.Success)
                 }
             }
         }.launchIn(viewModelScope)
+    }
+
+    private fun setInitUiState(): UiState {
+        return if (UserManager.isSignIn()) {
+            UiState.Success
+        } else {
+            UiState.Idle
+        }
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/UserManager.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/UserManager.kt
@@ -12,8 +12,4 @@ object UserManager {
     fun getUser(): FirebaseUser? {
         return auth.currentUser
     }
-
-    fun getNotNullSignInUser(): FirebaseUser {
-        return auth.currentUser!!
-    }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/UserManager.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/UserManager.kt
@@ -1,0 +1,19 @@
+package com.and04.naturealbum.ui.mypage
+
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+
+object UserManager {
+    private val auth = Firebase.auth
+
+    fun isSignIn() = auth.currentUser != null
+
+    fun getUser(): FirebaseUser? {
+        return auth.currentUser
+    }
+
+    fun getNotNullSignInUser(): FirebaseUser {
+        return auth.currentUser!!
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,12 @@
     <string name="home_navigate_to_album">나의 도감</string>
     <string name="home_navigate_to_camera">카메라</string>
     <string name="home_text_loading">Loading...</string>
+
+
+    <!-- My Page -->
+    <string name="my_page_arrow_back_icon_content_description">navigate My Page To Home</string>
+    <string name="my_page_user_profile_image">My Page User Profile Image</string>
+    <string name="my_page_default_user_email">현재 비회원 계정입니다.</string>
+    <string name="my_page_google_login_btn">구글</string>
+    <string name="my_page_login_txt">로그인</string>
 </resources>


### PR DESCRIPTION
### 완료한 기능
- 마이 페이지 UI 구현
- 로그인 시 유저 정보 가져와 이메일 / 프로필 이미지 표시

### 개발 관련 문서
[마이페이지 구현하기! | WIKI](https://github.com/boostcampwm-2024/and04-Nature-Album/wiki/마이페이지_구현하기)

### 고려해야할 부분
- 이미지와 이메일이 동시에 로딩되는 것이 아니라 따로 로딩된다.

https://github.com/user-attachments/assets/1ea2d3fd-a3f9-4538-8036-4122f3244801


- UI가 간단하여 Screen Rotation 관련해서 아직은 문제가 없다.
- 하지만 조금 더 복잡해지면 대응해야 한다.

https://github.com/user-attachments/assets/17d11496-df49-4f16-a909-44887f25ea87



