### PR TITLE
[SacePhotoScreen] ConfigurationChange 대응

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.location.Location
 import android.net.Uri
 import android.provider.MediaStore
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -104,6 +105,7 @@ fun NatureAlbumNavHost(
         }
 
         composable(NavigateDestination.SavePhoto.route) {
+            Log.d("FFFF", "navi")
             SavePhotoScreen(
                 location = lastLocation,
                 model = imageUri,

--- a/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.location.Location
 import android.net.Uri
 import android.provider.MediaStore
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -105,7 +104,6 @@ fun NatureAlbumNavHost(
         }
 
         composable(NavigateDestination.SavePhoto.route) {
-            Log.d("FFFF", "navi")
             SavePhotoScreen(
                 location = lastLocation,
                 model = imageUri,

--- a/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
@@ -116,7 +116,8 @@ fun NatureAlbumNavHost(
                 label = selectedLabel,
                 onLabelSelect = {
                     navController.navigate(NavigateDestination.SearchLabel.route)
-                }
+                },
+                onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }
 
@@ -132,7 +133,8 @@ fun NatureAlbumNavHost(
                 onLabelClick = { labelId ->
                     selectedAlbumLabel = labelId
                     navController.navigate(NavigateDestination.AlbumFolder.route)
-                }
+                },
+                onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }
 
@@ -142,12 +144,16 @@ fun NatureAlbumNavHost(
                 onPhotoClick = { labelId ->
                     selectedPhotoDetail = labelId
                     navController.navigate(NavigateDestination.PhotoInfo.route)
-                }
+                },
+                onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }
 
         composable(NavigateDestination.PhotoInfo.route) {
-            PhotoInfo(selectedPhotoDetail)
+            PhotoInfo(
+                selectedPhotoDetail = selectedPhotoDetail,
+                onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
+            )
         }
 
         composable(NavigateDestination.MyPage.route) {

--- a/app/src/main/java/com/and04/naturealbum/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/album/AlbumScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -39,9 +39,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import com.and04.naturealbum.data.dto.AlbumDto
 import com.and04.naturealbum.ui.component.AlbumLabel
-import com.and04.naturealbum.ui.component.PortraitTopAppBar
 import com.and04.naturealbum.ui.savephoto.UiState
 import com.and04.naturealbum.ui.theme.NatureAlbumTheme
+import com.and04.naturealbum.utils.GetTopbar
+import com.and04.naturealbum.utils.gridColumnCount
 import com.and04.naturealbum.utils.toColor
 
 @Composable
@@ -77,10 +78,12 @@ fun AlbumItem(album: AlbumDto, onLabelClick: (Int) -> Unit, modifier: Modifier =
 }
 
 @Composable
-fun AlbumGrid(albums: List<AlbumDto>, onLabelClick: (Int) -> Unit) {
-    val configuration = LocalConfiguration.current
-    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-    val columnCount = if (isPortrait) 2 else 4
+fun AlbumGrid(
+    albums: List<AlbumDto>,
+    onLabelClick: (Int) -> Unit,
+    columnCount: Int,
+) {
+
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(columnCount),
@@ -101,7 +104,11 @@ fun AlbumGrid(albums: List<AlbumDto>, onLabelClick: (Int) -> Unit) {
 }
 
 @Composable
-fun AlbumScreen(onLabelClick: (Int) -> Unit, viewModel: AlbumViewModel = hiltViewModel()) {
+fun AlbumScreen(
+    onLabelClick: (Int) -> Unit,
+    viewModel: AlbumViewModel = hiltViewModel(),
+    onNavigateToMyPage: () -> Unit,
+) {
     val isDataLoaded = rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(onLabelClick) {
         if (!isDataLoaded.value) {
@@ -109,6 +116,7 @@ fun AlbumScreen(onLabelClick: (Int) -> Unit, viewModel: AlbumViewModel = hiltVie
             isDataLoaded.value = true
         }
     }
+
     val uiState = viewModel.uiState.observeAsState()
     val albumList by viewModel.albumList.observeAsState()
 
@@ -118,7 +126,9 @@ fun AlbumScreen(onLabelClick: (Int) -> Unit, viewModel: AlbumViewModel = hiltVie
         }
 
         UiState.Success -> {
-            Scaffold(topBar = { PortraitTopAppBar() }) { paddingValues ->
+            Scaffold(
+                topBar = { LocalContext.current.GetTopbar { onNavigateToMyPage() } }
+            ) { paddingValues ->
                 Column(
                     modifier = Modifier
                         .padding(paddingValues)
@@ -127,7 +137,8 @@ fun AlbumScreen(onLabelClick: (Int) -> Unit, viewModel: AlbumViewModel = hiltVie
                     albumList?.let { albumList ->
                         AlbumGrid(
                             albums = albumList,
-                            onLabelClick = onLabelClick
+                            onLabelClick = onLabelClick,
+                            columnCount = LocalContext.current.gridColumnCount(),
                         )
                     }
                 }
@@ -149,7 +160,7 @@ fun AlbumScreen(onLabelClick: (Int) -> Unit, viewModel: AlbumViewModel = hiltVie
 
 @Composable
 fun AlbumLabelPreview() {
-    NatureAlbumTheme() {
+    NatureAlbumTheme {
         Surface {
             Column(
                 modifier = Modifier
@@ -199,7 +210,10 @@ fun AlbumLabelPreview() {
 fun AlbumScreenPreview() {
     NatureAlbumTheme {
         Surface {
-            AlbumScreen(onLabelClick = {})
+            AlbumScreen(
+                onLabelClick = {},
+                onNavigateToMyPage = {},
+            )
         }
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/album/AlbumScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,8 +13,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -79,29 +79,23 @@ fun AlbumItem(album: AlbumDto, onLabelClick: (Int) -> Unit, modifier: Modifier =
 @Composable
 fun AlbumGrid(albums: List<AlbumDto>, onLabelClick: (Int) -> Unit) {
     val configuration = LocalConfiguration.current
-    val columnCount =
-        if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) 2 else 4
+    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+    val columnCount = if (isPortrait) 2 else 4
 
-    LazyColumn(
-        contentPadding = PaddingValues(horizontal = 36.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(32.dp)
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(columnCount),
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(24.dp),
+        horizontalArrangement = Arrangement.spacedBy(28.dp),
     ) {
-        itemsIndexed(albums.chunked(columnCount)) { _, rowItems ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(40.dp)
-            ) {
-                for (album in rowItems) {
-                    AlbumItem(
-                        album = album,
-                        onLabelClick = onLabelClick,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                if (rowItems.size < columnCount) {
-                    Spacer(modifier = Modifier.weight(1f))
-                }
-            }
+        items(
+            items = albums,
+            key = { albumDto -> albumDto.labelId }
+        ) { album ->
+            AlbumItem(
+                album = album,
+                onLabelClick = onLabelClick,
+            )
         }
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
@@ -3,7 +3,6 @@ package com.and04.naturealbum.ui.albumfolder
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.app.Activity
 import android.content.Intent
-import android.content.res.Configuration
 import android.graphics.Color.parseColor
 import android.net.Uri
 import android.provider.Settings
@@ -44,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -57,17 +55,19 @@ import coil3.compose.AsyncImage
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.PhotoDetail
 import com.and04.naturealbum.ui.component.AlbumLabel
-import com.and04.naturealbum.ui.component.PortraitTopAppBar
 import com.and04.naturealbum.ui.component.RotatingImageLoading
 import com.and04.naturealbum.ui.home.PermissionDialogState
 import com.and04.naturealbum.ui.home.PermissionDialogs
 import com.and04.naturealbum.ui.savephoto.UiState
+import com.and04.naturealbum.utils.GetTopbar
+import com.and04.naturealbum.utils.gridColumnCount
 
 @Composable
 fun AlbumFolderScreen(
     selectedAlbumLabel: Int = 0,
     onPhotoClick: (Int) -> Unit,
     albumFolderViewModel: AlbumFolderViewModel = hiltViewModel(),
+    onNavigateToMyPage: () -> Unit,
 ) {
     val isDataLoaded = rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(selectedAlbumLabel) {
@@ -123,7 +123,9 @@ fun AlbumFolderScreen(
         }
     }
 
-    Scaffold(topBar = { PortraitTopAppBar() }) { innerPadding ->
+    Scaffold(
+        topBar = { context.GetTopbar { onNavigateToMyPage() } }
+    ) { innerPadding ->
         ItemContainer(
             innerPaddingValues = innerPadding,
             onPhotoClick = onPhotoClick,
@@ -166,9 +168,6 @@ private fun ItemContainer(
     savePhotos: () -> Unit,
     albumFolderViewModel: AlbumFolderViewModel = hiltViewModel(),
 ) {
-    val configuration = LocalConfiguration.current
-    val gridColumnCount =
-        if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) 2 else 4
     val uiState = albumFolderViewModel.uiState.collectAsStateWithLifecycle()
     val label = albumFolderViewModel.label.collectAsStateWithLifecycle()
     val photoDetails = albumFolderViewModel.photoDetails.collectAsStateWithLifecycle()
@@ -211,7 +210,7 @@ private fun ItemContainer(
                         modifier = Modifier.fillMaxSize(),
                     ) {
                         LazyVerticalStaggeredGrid(
-                            columns = StaggeredGridCells.Fixed(gridColumnCount),
+                            columns = StaggeredGridCells.Fixed(LocalContext.current.gridColumnCount()),
                             modifier = Modifier.fillMaxWidth(),
                             contentPadding = PaddingValues(24.dp),
                             horizontalArrangement = Arrangement.spacedBy(28.dp),

--- a/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -213,7 +212,6 @@ private fun ItemContainer(
                     ) {
                         LazyVerticalStaggeredGrid(
                             columns = StaggeredGridCells.Fixed(gridColumnCount),
-                            state = rememberLazyStaggeredGridState(),
                             modifier = Modifier.fillMaxWidth(),
                             contentPadding = PaddingValues(24.dp),
                             horizontalArrangement = Arrangement.spacedBy(28.dp),

--- a/app/src/main/java/com/and04/naturealbum/ui/component/AlbumLabel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/AlbumLabel.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import com.and04.naturealbum.ui.theme.AppTypography
 
 @Composable
@@ -26,7 +27,9 @@ fun AlbumLabel(
             text = text,
             color = calculatedTextColor,
             style = AppTypography.labelMedium,
-            fontWeight = FontWeight.SemiBold
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/component/ClippingButton.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/ClippingButton.kt
@@ -100,7 +100,6 @@ fun ClippingButtonWithFile(
         parsedPathData = svgData.pathData
         parsedViewportWidth = svgData.viewportWidth
         parsedViewportHeight = svgData.viewportHeight
-
     }
 
     Box(

--- a/app/src/main/java/com/and04/naturealbum/ui/component/NavigationImageButton.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/NavigationImageButton.kt
@@ -12,7 +12,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.and04.naturealbum.R
 
 @Composable
 fun NavigationImageButton(
@@ -28,7 +30,7 @@ fun NavigationImageButton(
     ) {
         Image(
             imageVector = imageVector,
-            contentDescription = null,
+            contentDescription = stringResource(R.string.component_navigation_image_button),
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.FillBounds,
         )

--- a/app/src/main/java/com/and04/naturealbum/ui/component/TopAppBar.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/component/TopAppBar.kt
@@ -21,7 +21,7 @@ import com.and04.naturealbum.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PortraitTopAppBar(onClick: () -> Unit = { }) {
+fun PortraitTopAppBar(onClick: () -> Unit) {
     TopAppBar(
         title = {
             Text(stringResource(R.string.app_name))
@@ -38,7 +38,7 @@ fun PortraitTopAppBar(onClick: () -> Unit = { }) {
 }
 
 @Composable
-fun LandscapeTopAppBar(onClick: () -> Unit = { }) {
+fun LandscapeTopAppBar(onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreen.kt
@@ -3,7 +3,6 @@ package com.and04.naturealbum.ui.home
 import android.app.Activity
 import android.app.Activity.RESULT_OK
 import android.content.Intent
-import android.content.res.Configuration
 import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -20,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -29,6 +27,7 @@ import androidx.core.app.ActivityCompat
 import com.and04.naturealbum.R
 import com.and04.naturealbum.ui.LocationHandler
 import com.and04.naturealbum.ui.component.NavigationImageButton
+import com.and04.naturealbum.utils.isPortrait
 
 const val MAP_BUTTON_BACKGROUND_OUTLINE_SVG = "btn_home_menu_map_background_outline.svg"
 
@@ -102,11 +101,7 @@ fun HomeScreen(
         )
     }
 
-
-    val configuration = LocalConfiguration.current
-    val isPortarit = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-
-    if (isPortarit) {
+    if (context.isPortrait()) {
         HomeScreenPortrait(
             context = context,
             permissionHandler = permissionHandler,

--- a/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenLandscape.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.and04.naturealbum.R
 import com.and04.naturealbum.ui.component.ClippingButtonWithFile
-import com.and04.naturealbum.ui.component.LandscapeTopAppBar
+import com.and04.naturealbum.utils.GetTopbar
 
 @Composable
 fun HomeScreenLandscape(
@@ -29,7 +29,9 @@ fun HomeScreenLandscape(
     onNavigateToAlbum: () -> Unit,
     onNavigateToMyPage: () -> Unit,
 ) {
-    Scaffold { innerPadding ->
+    Scaffold(
+        topBar = { context.GetTopbar { onNavigateToMyPage() } }
+    ) { innerPadding ->
         MainBackground(Modifier.fillMaxSize())
         Row(
             modifier = Modifier.padding(innerPadding)
@@ -43,7 +45,7 @@ fun HomeScreenLandscape(
                 Column(
                     modifier = Modifier.fillMaxSize()
                 ) {
-                    LandscapeTopAppBar { onNavigateToMyPage() }
+                    // TODO:  
                 }
             }
 

--- a/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenLandscape.kt
@@ -45,7 +45,7 @@ fun HomeScreenLandscape(
                 Column(
                     modifier = Modifier.fillMaxSize()
                 ) {
-                    // TODO:  
+                    // TODO:  나중에 새로운 컴포넌트 추가
                 }
             }
 

--- a/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/home/HomeScreenPortrait.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.and04.naturealbum.R
 import com.and04.naturealbum.ui.component.ClippingButtonWithFile
-import com.and04.naturealbum.ui.component.PortraitTopAppBar
+import com.and04.naturealbum.utils.GetTopbar
 
 @Composable
 fun HomeScreenPortrait(
@@ -22,7 +22,9 @@ fun HomeScreenPortrait(
     onNavigateToAlbum: () -> Unit,
     onNavigateToMyPage: () -> Unit,
 ) {
-    Scaffold(topBar = { PortraitTopAppBar { onNavigateToMyPage() } }) { innerPadding ->
+    Scaffold(
+        topBar = { context.GetTopbar { onNavigateToMyPage() } }
+    ) { innerPadding ->
         Column(
             modifier = Modifier
                 .padding(innerPadding)

--- a/app/src/main/java/com/and04/naturealbum/ui/photoinfo/PhotoInfo.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/photoinfo/PhotoInfo.kt
@@ -44,13 +44,14 @@ import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
 import com.and04.naturealbum.data.room.PhotoDetail
 import com.and04.naturealbum.ui.component.AlbumLabel
-import com.and04.naturealbum.ui.component.PortraitTopAppBar
 import com.and04.naturealbum.ui.savephoto.UiState
+import com.and04.naturealbum.utils.GetTopbar
 
 @Composable
 fun PhotoInfo(
     selectedPhotoDetail: Int = 0,
     photoInfoViewModel: PhotoInfoViewModel = hiltViewModel(),
+    onNavigateToMyPage: () -> Unit,
 ) {
     val isDataLoaded = rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(selectedPhotoDetail) {
@@ -59,7 +60,9 @@ fun PhotoInfo(
             isDataLoaded.value = true
         }
     }
-    Scaffold(topBar = { PortraitTopAppBar() }) { innerPadding ->
+    Scaffold(
+        topBar = { LocalContext.current.GetTopbar { onNavigateToMyPage() } }
+    ) { innerPadding ->
         Content(innerPadding = innerPadding)
     }
 }
@@ -249,5 +252,7 @@ private fun RowInfo(
 @Preview
 @Composable
 private fun PhotoInfoPreview() {
-    PhotoInfo()
+    PhotoInfo(
+        onNavigateToMyPage = {}
+    )
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/photoinfo/PhotoInfo.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/photoinfo/PhotoInfo.kt
@@ -50,8 +50,8 @@ import com.and04.naturealbum.utils.GetTopbar
 @Composable
 fun PhotoInfo(
     selectedPhotoDetail: Int = 0,
-    photoInfoViewModel: PhotoInfoViewModel = hiltViewModel(),
     onNavigateToMyPage: () -> Unit,
+    photoInfoViewModel: PhotoInfoViewModel = hiltViewModel(),
 ) {
     val isDataLoaded = rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(selectedPhotoDetail) {

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
@@ -13,9 +13,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -156,13 +155,9 @@ fun ToggleButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Spacer(modifier = modifier.size(24.dp))
     Row(
         modifier = modifier
-            .padding(vertical = 8.dp)
-            .clickable(
-                onClick = { onClick() }
-            ),
+            .clickable(onClick = { onClick() }),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
@@ -183,20 +178,15 @@ fun LabelSelection(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-
-    Column(modifier = modifier) {
+    Column(modifier = modifier.padding(horizontal = 12.dp)) {
         Text(
             stringResource(R.string.save_photo_screen_label),
-            modifier = modifier,
             style = MaterialTheme.typography.headlineLarge,
             fontSize = TextUnit(20f, TextUnitType.Sp),
         )
-        Spacer(modifier = modifier.size(8.dp))
         Button(
             onClick = { onClick() },
-            modifier = modifier
-                .fillMaxWidth(),
-            contentPadding = PaddingValues(all = 4.dp),
+            modifier = modifier.fillMaxWidth(),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 contentColor = MaterialTheme.colorScheme.onSurfaceVariant
@@ -209,39 +199,31 @@ fun LabelSelection(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    modifier = modifier
-                        .padding(12.dp)
-                        .size(24.dp),
                     imageVector = Icons.Default.Menu,
                     contentDescription = null
                 )
                 Box(
                     modifier = modifier
                         .weight(1f)
-                        .padding(horizontal = 4.dp)
+                        .padding(horizontal = 24.dp)
                 ) {
                     label?.let {
                         val backgroundColor = Color(label.backgroundColor.toLong(16))
                         SuggestionChip(
                             onClick = { onClick() },
-                            label = {
-                                Text(text = label.name)
-                            },
+                            label = { Text(text = label.name) },
                             colors = SuggestionChipDefaults.suggestionChipColors(
                                 containerColor = backgroundColor,
                                 labelColor = if (backgroundColor.luminance() > 0.5f) Color.Black else Color.White,
-                            )
+                            ),
+                            modifier = Modifier.heightIn(max = 24.dp)
                         )
-                    }
-                        ?: Text(text = stringResource(R.string.save_photo_screen_select_label))
+                    } ?: Text(text = stringResource(R.string.save_photo_screen_select_label))
                 }
             }
             Icon(
-                modifier = modifier
-                    .padding(12.dp)
-                    .size(24.dp),
                 imageVector = Icons.Default.Search,
-                contentDescription = null
+                contentDescription = null,
             )
         }
     }
@@ -253,21 +235,21 @@ fun Description(
     modifier: Modifier,
     onValueChange: (String) -> Unit,
 ) {
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier.padding(12.dp)
+    ) {
         Text(
             stringResource(R.string.save_photo_screen_description),
-            modifier = modifier,
             style = MaterialTheme.typography.headlineLarge,
             fontSize = TextUnit(20f, TextUnitType.Sp),
         )
-        Spacer(modifier = modifier.size(8.dp))
         TextField(
             value = description,
             onValueChange = { text -> onValueChange(text) },
             placeholder = { Text(stringResource(R.string.save_photo_screen_description_about_photo)) },
             modifier = modifier
+                .weight(1f)
                 .fillMaxWidth()
-                .height(120.dp),
         )
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
@@ -77,6 +77,7 @@ fun SavePhotoScreen(
     label: Label? = null,
     modifier: Modifier = Modifier,
     viewModel: SavePhotoViewModel = hiltViewModel(),
+    onNavigateToMyPage: () -> Unit,
 ) {
     val uiState = viewModel.uiState.collectAsState() // TODO : 상태 변경시 로딩화면등 화면 변경, 없으면 이름 변경 고려
     var rememberDescription by rememberSaveable { mutableStateOf(description) }
@@ -336,7 +337,8 @@ private fun ScreenPreview() {
             label = Label(0, "0000FF", "cat"),
             onBack = { },
             onSave = {},
-            onLabelSelect = {})
+            onLabelSelect = {},
+            onNavigateToMyPage = {})
     }
 }
 
@@ -350,7 +352,8 @@ private fun ScreenEmptyPreview() {
             model = R.drawable.fish_loading_image,
             onBack = { },
             onSave = {},
-            onLabelSelect = {})
+            onLabelSelect = {},
+            onNavigateToMyPage = {})
     }
 }
 
@@ -369,6 +372,7 @@ private fun ScreenDescriptionPreview() {
             label = Label(0, "FFFFFF", "cat"),
             onBack = { },
             onSave = {},
-            onLabelSelect = {})
+            onLabelSelect = {},
+            onNavigateToMyPage = {})
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
@@ -3,7 +3,6 @@ package com.and04.naturealbum.ui.savephoto
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.location.Location
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
@@ -23,7 +22,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -51,11 +49,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
+import com.and04.naturealbum.ui.component.RotatingImageLoading
 import com.and04.naturealbum.ui.theme.NatureAlbumTheme
 import com.and04.naturealbum.utils.GetTopbar
 import com.and04.naturealbum.utils.isPortrait
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SavePhotoScreen(
     location: Location?,
@@ -65,26 +63,36 @@ fun SavePhotoScreen(
     onLabelSelect: () -> Unit,
     description: String = "",
     label: Label? = null,
-    modifier: Modifier = Modifier,
     viewModel: SavePhotoViewModel = hiltViewModel(),
     onNavigateToMyPage: () -> Unit,
 ) {
-    Log.d(
-        "FFFF", "save " +
-                "\nlocation:${location}" +
-                "\nmodel:${model}" +
-                "\nlabel:${label}" +
-                "\ndescrip:${description}"
-    )
     // TODO : 상태 변경시 로딩화면등 화면 변경, 없으면 이름 변경 고려
     val photoSaveState = viewModel.photoSaveState.collectAsStateWithLifecycle()
     val rememberDescription = rememberSaveable { mutableStateOf(description) }
     val isRepresented = rememberSaveable { mutableStateOf(false) }
+
     if (photoSaveState.value == UiState.Success) {
         onSave()
     }
 
+    viewModel.setPhotoLoadingUiSate(UiState.Idle)
+    val photoLoadingUiState = viewModel.photoLoadingUiState.collectAsStateWithLifecycle()
+
+    when (photoLoadingUiState.value) {
+        UiState.Idle, UiState.Loading -> {
+            RotatingImageLoading(
+                drawalbeRes = R.drawable.fish_loading_image,
+                stringRes = R.string.save_photo_screen_loading
+            )
+        }
+
+        UiState.Success -> {
+            // TODO:  
+        }
+    }
+
     BackHandler(onBack = onBack)
+
     Scaffold(
         topBar = { LocalContext.current.GetTopbar { onNavigateToMyPage() } },
     ) { innerPadding ->

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
@@ -51,7 +52,7 @@ fun SavePhotoScreenLandscape(
                     .data(model)
                     .crossfade(true)
                     .build(),
-                contentDescription = null,
+                contentDescription = stringResource(R.string.save_photo_screen_image_description),
                 modifier = Modifier
                     .weight(1f)
                     .align(Alignment.CenterHorizontally)

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
@@ -42,7 +42,7 @@ fun SavePhotoScreenLandscape(
     Row(
         modifier = Modifier.padding(innerPadding)
     ) {
-        //오른쪽
+        //왼쪽
         Column(
             modifier = Modifier.weight(1f)
         ) {
@@ -62,14 +62,16 @@ fun SavePhotoScreenLandscape(
                 selected = isRepresented.value,
                 onClick = { isRepresented.value = !isRepresented.value },
                 modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 12.dp)
             )
         }
 
-        //왼쪽
+        //오른쪽
         Column(
             modifier = Modifier.weight(1f)
         ) {
-            LabelSelection(label, onClick = onLabelSelect, modifier = Modifier.weight(1f))
+            LabelSelection(label = label, onClick = onLabelSelect)
 
             Description(
                 description = rememberDescription.value,
@@ -79,7 +81,6 @@ fun SavePhotoScreenLandscape(
 
             Row(
                 modifier = Modifier
-                    .weight(1f)
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
                 horizontalArrangement = Arrangement.spacedBy(30.dp),

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
@@ -1,0 +1,110 @@
+package com.and04.naturealbum.ui.savephoto
+
+import android.location.Location
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Create
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.and04.naturealbum.R
+import com.and04.naturealbum.data.room.Label
+
+@Composable
+fun SavePhotoScreenLandscape(
+    innerPadding: PaddingValues,
+    model: Any,
+    label: Label?,
+    location: Location?,
+    rememberDescription: MutableState<String>,
+    isRepresented: MutableState<Boolean>,
+    photoSaveState: State<UiState>,
+    onLabelSelect: () -> Unit,
+    onBack: () -> Unit,
+    viewModel: SavePhotoViewModel = hiltViewModel(),
+) {
+    Row(
+        modifier = Modifier.padding(innerPadding)
+    ) {
+        //오른쪽
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(model)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = null,
+                modifier = Modifier
+                    .weight(1f)
+                    .align(Alignment.CenterHorizontally)
+                    .clip(RoundedCornerShape(10.dp))
+            )
+
+            ToggleButton(
+                selected = isRepresented.value,
+                onClick = { isRepresented.value = !isRepresented.value },
+                modifier = Modifier
+            )
+        }
+
+        //왼쪽
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            LabelSelection(label, onClick = onLabelSelect, modifier = Modifier.weight(1f))
+
+            Description(
+                description = rememberDescription.value,
+                modifier = Modifier.weight(1f),
+                onValueChange = { newDescription -> rememberDescription.value = newDescription }
+            )
+
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(30.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconTextButton(
+                    modifier = Modifier.weight(1f),
+                    imageVector = Icons.Default.Close,
+                    stringRes = R.string.save_photo_screen_cancel,
+                    onClick = { onBack() })
+                IconTextButton(
+                    enabled = (label != null) && (photoSaveState.value != UiState.Loading),
+                    modifier = Modifier.weight(1f),
+                    imageVector = Icons.Outlined.Create,
+                    stringRes = R.string.save_photo_screen_save,
+                    onClick = {
+                        viewModel.savePhoto(
+                            uri = model.toString(),
+                            label = label!!,
+                            description = rememberDescription.value,
+                            location = location!!, // TODO : Null 처리 필요
+                            isRepresented = isRepresented.value
+                        )
+                    })
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
@@ -5,11 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -43,10 +40,7 @@ fun SavePhotoScreenPortrait(
     viewModel: SavePhotoViewModel = hiltViewModel(),
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(innerPadding)
-            .padding(horizontal = 16.dp)
+        modifier = Modifier.padding(innerPadding)
     ) {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
@@ -60,12 +54,13 @@ fun SavePhotoScreenPortrait(
                 .clip(RoundedCornerShape(10.dp))
         )
 
-        Spacer(modifier = Modifier.size(36.dp))
-        LabelSelection(label, onClick = onLabelSelect, modifier = Modifier)
+        LabelSelection(
+            label = label,
+            onClick = onLabelSelect,
+        )
 
-        Spacer(modifier = Modifier.size(36.dp))
         Description(description = rememberDescription.value,
-            modifier = Modifier,
+            modifier = Modifier.weight(1f),
             onValueChange = { newDescription -> rememberDescription.value = newDescription }
         )
 
@@ -73,9 +68,10 @@ fun SavePhotoScreenPortrait(
             selected = isRepresented.value,
             onClick = { isRepresented.value = !isRepresented.value },
             modifier = Modifier
+                .padding(vertical = 8.dp)
+                .padding(start = 8.dp)
         )
 
-        Spacer(modifier = Modifier.size(36.dp))
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
@@ -1,0 +1,108 @@
+package com.and04.naturealbum.ui.savephoto
+
+import android.location.Location
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Create
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import com.and04.naturealbum.R
+import com.and04.naturealbum.data.room.Label
+
+@Composable
+fun SavePhotoScreenPortrait(
+    innerPadding: PaddingValues,
+    model: Any,
+    label: Label?,
+    location: Location?,
+    rememberDescription: MutableState<String>,
+    isRepresented: MutableState<Boolean>,
+    photoSaveState: State<UiState>,
+    onLabelSelect: () -> Unit,
+    onBack: () -> Unit,
+    viewModel: SavePhotoViewModel = hiltViewModel(),
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
+            .padding(horizontal = 16.dp)
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(model)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            modifier = Modifier
+                .weight(1f)
+                .align(Alignment.CenterHorizontally)
+                .clip(RoundedCornerShape(10.dp))
+        )
+
+        Spacer(modifier = Modifier.size(36.dp))
+        LabelSelection(label, onClick = onLabelSelect, modifier = Modifier)
+
+        Spacer(modifier = Modifier.size(36.dp))
+        Description(description = rememberDescription.value,
+            modifier = Modifier,
+            onValueChange = { newDescription -> rememberDescription.value = newDescription }
+        )
+
+        ToggleButton(
+            selected = isRepresented.value,
+            onClick = { isRepresented.value = !isRepresented.value },
+            modifier = Modifier
+        )
+
+        Spacer(modifier = Modifier.size(36.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(30.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconTextButton(
+                modifier = Modifier.weight(1f),
+                imageVector = Icons.Default.Close,
+                stringRes = R.string.save_photo_screen_cancel,
+                onClick = { onBack() })
+            IconTextButton(
+                enabled = (label != null) && (photoSaveState.value != UiState.Loading),
+                modifier = Modifier.weight(1f),
+                imageVector = Icons.Outlined.Create,
+                stringRes = R.string.save_photo_screen_save,
+                onClick = {
+                    viewModel.savePhoto(
+                        uri = model.toString(),
+                        label = label!!,
+                        description = rememberDescription.value,
+                        location = location!!, // TODO : Null 처리 필요
+                        isRepresented = isRepresented.value
+                    )
+                })
+        }
+
+    }
+}

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
@@ -47,7 +48,7 @@ fun SavePhotoScreenPortrait(
                 .data(model)
                 .crossfade(true)
                 .build(),
-            contentDescription = null,
+            contentDescription = stringResource(R.string.save_photo_screen_image_description),
             modifier = Modifier
                 .weight(1f)
                 .align(Alignment.CenterHorizontally)

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
@@ -28,8 +28,15 @@ class SavePhotoViewModel @Inject constructor(
     private val repository: DataRepository,
 ) : ViewModel() {
 
+    private val _photoLoadingUiState = MutableStateFlow<UiState>(UiState.Idle)
+    val photoLoadingUiState: StateFlow<UiState> = _photoLoadingUiState
+
     private val _photoSaveState = MutableStateFlow<UiState>(UiState.Idle)
     val photoSaveState: StateFlow<UiState> = _photoSaveState
+
+    fun setPhotoLoadingUiSate(uiState: UiState) {
+        _photoLoadingUiState.value = uiState
+    }
 
     fun savePhoto(
         uri: String,

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
@@ -25,20 +25,20 @@ sealed class UiState {
 
 @HiltViewModel
 class SavePhotoViewModel @Inject constructor(
-    private val repository: DataRepository
+    private val repository: DataRepository,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
-    val uiState: StateFlow<UiState> = _uiState
+    private val _photoSaveState = MutableStateFlow<UiState>(UiState.Idle)
+    val photoSaveState: StateFlow<UiState> = _photoSaveState
 
     fun savePhoto(
         uri: String,
         label: Label,
         location: Location,
         description: String,
-        isRepresented: Boolean
+        isRepresented: Boolean,
     ) {
-        _uiState.value = UiState.Loading
+        _photoSaveState.value = UiState.Loading
         viewModelScope.launch(Dispatchers.IO) {
             val labelId =
                 if (label.id == 0) repository.insertLabel(label).toInt()
@@ -73,7 +73,7 @@ class SavePhotoViewModel @Inject constructor(
                 else {
                 }
             }
-            _uiState.emit(UiState.Success)
+            _photoSaveState.emit(UiState.Success)
         }
     }
 

--- a/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
@@ -1,0 +1,30 @@
+package com.and04.naturealbum.utils
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.and04.naturealbum.ui.component.LandscapeTopAppBar
+import com.and04.naturealbum.ui.component.PortraitTopAppBar
+
+fun Context.isPortrait(): Boolean {
+    return resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+}
+
+fun Context.isLandscape(): Boolean {
+    return resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+}
+
+@Composable
+fun Context.gridColumnCount(): Int {
+    return if (LocalContext.current.isPortrait()) 2 else 4
+}
+
+@Composable
+fun Context.GetTopbar(onNavigateToMyPage: () -> Unit) {
+    if (LocalContext.current.isPortrait()) {
+        PortraitTopAppBar { onNavigateToMyPage() }
+    } else {
+        LandscapeTopAppBar { onNavigateToMyPage() }
+    }
+}

--- a/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.platform.LocalContext
 import com.and04.naturealbum.ui.component.LandscapeTopAppBar
 import com.and04.naturealbum.ui.component.PortraitTopAppBar
 
+const val COLUMN_COUNT_PORTRAIT = 2
+const val COLUMN_COUNT_LANDSCAPE = 2
+
 fun Context.isPortrait(): Boolean {
     return resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 }
@@ -17,7 +20,7 @@ fun Context.isLandscape(): Boolean {
 
 @Composable
 fun Context.gridColumnCount(): Int {
-    return if (LocalContext.current.isPortrait()) 2 else 4
+    return if (LocalContext.current.isPortrait()) COLUMN_COUNT_PORTRAIT else COLUMN_COUNT_LANDSCAPE
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,9 @@
     <string name="save_photo_screen_select_label">라벨을 선택해주세요.</string>
     <string name="save_photo_screen_description">설명</string>
     <string name="save_photo_screen_description_about_photo">사진에 대한 설명을 추가할 수 있습니다.</string>
+    <string name="save_photo_screen_image_description">사진찍은 이미지</string>
+    <string name="save_photo_screen_saving">저장중</string>
+    <string name="save_photo_screen_loading">불러오는중..</string>
 
     <string name="photo_info_screen_calender_icon">달력 아이콘</string>
     <string name="photo_info_screen_location_icon">위치 아이콘</string>
@@ -44,4 +47,7 @@
     <string name="home_navigate_to_album">나의 도감</string>
     <string name="home_navigate_to_camera">카메라</string>
     <string name="home_text_loading">Loading...</string>
+
+    <!-- component -->
+    <string name="component_navigation_image_button">네비게이션 이미지 버튼</string>
 </resources>


### PR DESCRIPTION
# 진행 완료 리스트

✅  사진 저장하는 화면 가로모드 

✅ 컴포저블 함수 유틸에 분리


<img width="801" alt="스크린샷 2024-11-14 오후 3 47 06" src="https://github.com/user-attachments/assets/6a06bd28-06c9-441f-8924-32d069764e32">
