### PR TITLE
[Fix] map theme error 해결

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.NatureAlbum" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.NatureAlbum" parent="Theme.AppCompat.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
# ✅  해결 사항
 
- Naver Maps SDK가 AppCompat 테마를 요구
- android:Theme.Material.Light.NoActionBar로 Material 테마를 사용하고 있어 AppCompat 호환성이 없어 문제가 발생
- 테마를 Theme.AppCompat.Light.NoActionBar로 변경 (values/themes.xml)