### PR TITLE
[Fix] 가로,세로 열 수정

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
+++ b/app/src/main/java/com/and04/naturealbum/utils/ComposeUtils.kt
@@ -8,7 +8,7 @@ import com.and04.naturealbum.ui.component.LandscapeTopAppBar
 import com.and04.naturealbum.ui.component.PortraitTopAppBar
 
 const val COLUMN_COUNT_PORTRAIT = 2
-const val COLUMN_COUNT_LANDSCAPE = 2
+const val COLUMN_COUNT_LANDSCAPE = 4
 
 fun Context.isPortrait(): Boolean {
     return resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT


### PR DESCRIPTION
가로모드일 때 그리드뷰의 열 개수가 4개로 되어야하는데, 2개로 지정했었다.