### PR TITLE
[Fix] SavePhotoScreen 애니메이션 무한 로딩 문제 해결

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
@@ -49,7 +49,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
-import com.and04.naturealbum.ui.component.RotatingImageLoading
 import com.and04.naturealbum.ui.theme.NatureAlbumTheme
 import com.and04.naturealbum.utils.GetTopbar
 import com.and04.naturealbum.utils.isPortrait
@@ -76,20 +75,6 @@ fun SavePhotoScreen(
     }
 
     viewModel.setPhotoLoadingUiSate(UiState.Idle)
-    val photoLoadingUiState = viewModel.photoLoadingUiState.collectAsStateWithLifecycle()
-
-    when (photoLoadingUiState.value) {
-        UiState.Idle, UiState.Loading -> {
-            RotatingImageLoading(
-                drawalbeRes = R.drawable.fish_loading_image,
-                stringRes = R.string.save_photo_screen_loading
-            )
-        }
-
-        UiState.Success -> {
-            // TODO:  
-        }
-    }
 
     BackHandler(onBack = onBack)
 


### PR DESCRIPTION
# 진행 완료 리스트

✅  뒤에서 몰래 무한 로딩되고 있던 이미지를 제거했습니다.