### PR TITLE
화면 전환 시 리컴포지션이 불필요하게 일어나는 로직 개선

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/NatureAlbumApp.kt
@@ -47,8 +47,6 @@ fun NatureAlbumNavHost(
 ) {
     val context = LocalContext.current
     var lastLocation: Location? by rememberSaveable { mutableStateOf(null) }
-    var selectedAlbumLabel: Int = remember { 0 }
-    var selectedPhotoDetail: Int = remember { 0 }
     val locationHandler = remember {
         LocationHandler(
             context = context
@@ -134,27 +132,29 @@ fun NatureAlbumNavHost(
         composable(NavigateDestination.Album.route) {
             AlbumScreen(
                 onLabelClick = { labelId ->
-                    selectedAlbumLabel = labelId
-                    navController.navigate(NavigateDestination.AlbumFolder.route)
+                    navController.navigate("${NavigateDestination.AlbumFolder.route}/$labelId")
                 },
                 onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }
 
-        composable(NavigateDestination.AlbumFolder.route) {
+        composable("${NavigateDestination.AlbumFolder.route}/{labelId}") { backStackEntry ->
+            val labelId = backStackEntry.arguments?.getString("labelId")?.toInt()!!
+
             AlbumFolderScreen(
-                selectedAlbumLabel,
-                onPhotoClick = { labelId ->
-                    selectedPhotoDetail = labelId
-                    navController.navigate(NavigateDestination.PhotoInfo.route)
+                selectedAlbumLabel = labelId,
+                onPhotoClick = { photoDetailId ->
+                    navController.navigate("${NavigateDestination.PhotoInfo.route}/$photoDetailId")
                 },
                 onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }
 
-        composable(NavigateDestination.PhotoInfo.route) {
+        composable("${NavigateDestination.PhotoInfo.route}/{photoDetailId}") { backStackEntry ->
+            val photoDetailId = backStackEntry.arguments?.getString("photoDetailId")?.toInt()!!
+
             PhotoInfo(
-                selectedPhotoDetail = selectedPhotoDetail,
+                selectedPhotoDetail = photoDetailId,
                 onNavigateToMyPage = { navController.navigate(NavigateDestination.MyPage.route) },
             )
         }

--- a/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
@@ -86,11 +87,9 @@ fun AlbumFolderScreen(
     val setLoading = { isImgDownLoading: Boolean -> state.imgDownLoading.value = isImgDownLoading }
     val switchEditMode = { isEditModeEnabled: Boolean -> state.editMode.value = isEditModeEnabled }
 
-
-    LaunchedEffect(selectedAlbumLabel) {
-        if (!state.isDataLoaded.value) {
+    LaunchedEffect(uiState.value) {
+        if (uiState.value is UiState.Idle) {
             albumFolderViewModel.loadFolderData(selectedAlbumLabel)
-            state.isDataLoaded.value = true
         }
     }
 
@@ -151,6 +150,7 @@ fun AlbumFolderScreen(
             stringRes = R.string.album_folder_screen_save_text
         )
     }
+
     PermissionDialogs(
         permissionDialogState = state.permissionDialogState.value,
         onDismiss = { state.permissionDialogState.value = PermissionDialogState.None },

--- a/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderState.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/albumfolder/AlbumFolderState.kt
@@ -11,14 +11,12 @@ import com.and04.naturealbum.ui.home.PermissionDialogState
 
 @Stable
 class AlbumFolderState(
-    isDataLoaded: Boolean,
     imgDownLoading: Boolean,
     editMode: Boolean,
     checkList: Set<PhotoDetail>,
     selectAll: Boolean,
     permissionDialogState: PermissionDialogState
 ) {
-    var isDataLoaded = mutableStateOf(isDataLoaded)
     var imgDownLoading = mutableStateOf(imgDownLoading)
     var editMode = mutableStateOf(editMode)
     var checkList = mutableStateOf(checkList)
@@ -28,7 +26,6 @@ class AlbumFolderState(
 
 @Composable
 fun rememberAlbumFolderState(
-    isDataLoaded: Boolean = false,
     imgDownLoading: Boolean = false,
     editMode: Boolean = false,
     checkList: Set<PhotoDetail> = setOf(),
@@ -37,7 +34,6 @@ fun rememberAlbumFolderState(
 ): AlbumFolderState {
     return remember {
         AlbumFolderState(
-            isDataLoaded = isDataLoaded,
             imgDownLoading = imgDownLoading,
             editMode = editMode,
             checkList = checkList,


### PR DESCRIPTION
### AlbumScreen

|수정 전|수정 후|
|:---:|:---:|
|![AlbumScreen Before](https://github.com/user-attachments/assets/7b0ffcf7-4ab1-4be2-a38a-a15b6e39e2a8)|![AlbumScreen After](https://github.com/user-attachments/assets/97a8f037-eb64-4b57-bca7-05fc6bdfbc6e)|

- 한 번의 리컴포지션은 데이터 load 로직에서 uiState Loading -> Success로 바뀌면서 일어나는 것

### AlbumFolderScreen

|수정 전|수정 후|
|:---:|:---:|
|![AlbumFolderScreen Before](https://github.com/user-attachments/assets/47072943-69e7-4067-a42c-f3e831dcb913)|![albumFolderScreen After](https://github.com/user-attachments/assets/7c4de9b6-01f2-43e6-b0a4-ff722636a0ee)|

- 3번의 리컴포지션은 아래와 같다.
![image](https://github.com/user-attachments/assets/9aa065e9-8247-48a6-8d7d-c034f8e3724b)

