### PR TITLE
서버 필터링을 통한 친구 검색 기능 구현 및 UI 구성 변경

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/data/repository/FireBaseRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/FireBaseRepository.kt
@@ -469,6 +469,6 @@ class FireBaseRepositoryImpl @Inject constructor(
         private const val FRIENDS = "FRIENDS"
         private const val FRIEND_REQUESTS = "FRIEND_REQUESTS"
         private const val EMAIL = "email"
-        private const val QUERY_SUFFIX = "\uf8ff"
+        private const val QUERY_SUFFIX = "\uf8ff" // Firestore 쿼리에서 startsWith 구현을 위한 문자열 끝 범위 문자
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/friend/FriendViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/friend/FriendViewModel.kt
@@ -3,7 +3,6 @@ package com.and04.naturealbum.ui.friend
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.room.util.query
 import com.and04.naturealbum.data.dto.FirebaseFriend
 import com.and04.naturealbum.data.dto.FirebaseFriendRequest
 import com.and04.naturealbum.data.dto.FirestoreUser

--- a/app/src/main/java/com/and04/naturealbum/ui/friend/FriendViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/friend/FriendViewModel.kt
@@ -55,14 +55,13 @@ class FriendViewModel @Inject constructor(
                 .filter { query -> query.isNotBlank() } // 빈 쿼리 무시
                 .distinctUntilChanged() // 중복 값 방지
                 .collect { query ->
-                    val currentUid = UserManager.getUser()?.uid
-                    if (currentUid != null) {
-                        fetchFilteredUsers(currentUid = currentUid, query = query)
-                    } else {
-                        Log.e("FriendViewModel", "UID is null, skipping search.")
+                    UserManager.getUser()?.uid?.let { currentUid ->
+                        fetchFilteredUsers(
+                            currentUid = currentUid,
+                            query = query
+                        )
                     }
                 }
-
         }
     }
 

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
@@ -80,6 +80,7 @@ fun MyPageSocialItem(myFriend: FirebaseFriend) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyPageSearch(
+    onSearchQueryChange: (String) -> Unit,
     userWithStatusList: List<FirestoreUserWithStatus>,
     currentUid: String,
     sendFriendRequest: (String, String) -> Unit,
@@ -108,14 +109,14 @@ fun MyPageSearch(
                             contentDescription = stringResource(R.string.my_page_search_bar_search_icon)
                         )
                     },
-                    onQueryChange = { textField ->
-                        textFieldState = textField
-                    }
+                    onQueryChange = { query ->
+                        textFieldState = query
+                        onSearchQueryChange(query) // 검색 쿼리 변경 시 호출
+                    },
                 )
             },
-            expanded = expanded,
-            onExpandedChange = { expandedChange ->
-                expanded = expandedChange
+            expanded = false,
+            onExpandedChange = {
             },
         ) {
             // 검색 결과 리스트

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
@@ -127,7 +127,7 @@ fun MyPageSearch(
             )
         }
 
-        // 요청된 친구 리스트
+        // 검색 결과 리스트
         RequestedList(
             userWithStatusList = userWithStatusList,
             currentUid = currentUid,

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageItems.kt
@@ -91,6 +91,14 @@ fun MyPageSearch(
     Column(
         Modifier.fillMaxSize()
     ) {
+
+        // TODO: 키보드 올라왔을 때 검색 결과 부분까지 위로 올라가는 것 필요
+        RequestedList(
+            userWithStatusList = userWithStatusList,
+            currentUid = currentUid,
+            sendFriendRequest = sendFriendRequest
+        )
+
         SearchBar(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally),
@@ -127,12 +135,6 @@ fun MyPageSearch(
             )
         }
 
-        // 검색 결과 리스트
-        RequestedList(
-            userWithStatusList = userWithStatusList,
-            currentUid = currentUid,
-            sendFriendRequest = sendFriendRequest
-        )
     }
 }
 


### PR DESCRIPTION
### ✅ 구현한 기능:

1. **친구 검색 기능 구현**:
    - `FriendViewModel`에서 `searchQuery`를 받아 `debounce`를 적용하여 사용자가 검색어를 입력할 때마다 서버로 쿼리 요청을 보내는 방식으로 구현했습니다.
    - 검색 결과는 `FirestoreUserWithStatus` 객체로 받아 상태에 따라 친구 요청 상태 또는 친구 관계 정보를 제공합니다.
2. **서버에서 사용자 검색**:
    - `searchUsers` 메서드에서는 `Firestore`의 `whereGreaterThanOrEqualTo`와 `whereLessThanOrEqualTo`를 사용해 이메일을 기준으로 사용자들을 검색합니다. 이 방식은 검색어에 맞는 이메일을 찾는 데 사용됩니다.
    - 검색 결과를 `StateFlow`에 반영하여 UI에서 바로 갱신될 수 있도록 설정되었습니다.

### ☑️ 추후 보완할 부분:

**UI에서 검색 시 키보드 처리**

- 현재 검색을 누르면 UI가 키보드보다 위로 올라가야 하는데, 이 부분이 아직 해결되지 않았습니다. **키보드가 올라올 때 `RequestedList`와 `SearchBar`의 위치를 적절히 조정**할 수 있도록 개선이 필요합니다.
- `windowInsets`나 `imePadding()`을 활용하여 UI가 적절히 이동하도록 시도했으나, 아직 해결되지 않았습니다. 이후 추가적으로 이 문제를 해결할 필요가 있습니다.

### 🎥 작동 영상

https://github.com/user-attachments/assets/10ffd045-7f7b-4ea1-93df-8065b29a47ac

### 개발 문서 링크
[Firebase 친구 기능 (2) - 친구 검색](https://github.com/boostcampwm-2024/and04-Nature-Album/wiki/Firebase_%EC%B9%9C%EA%B5%AC_%EA%B8%B0%EB%8A%A5_(2)_-_%EC%B9%9C%EA%B5%AC_%EA%B2%80%EC%83%89)

