### PR TITLE
양방향 동기화

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
@@ -20,8 +20,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
-import java.time.ZoneId
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -65,7 +63,8 @@ class FirebaseInsertService : Service() {
                             labelName = label.name,
                             labelData = FirebaseLabel(
                                 backgroundColor = label.backgroundColor,
-                                thumbnailUri = storageUri.toString()
+                                thumbnailUri = storageUri.toString(),
+                                fileName = fileName
                             )
                         )
                 }

--- a/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
@@ -36,6 +36,7 @@ class FirebaseInsertService : Service() {
             val uid = Firebase.auth.currentUser!!.uid
             val uri = intent?.getStringExtra(SERVICE_URI) as String
             val fileName = intent.getStringExtra(SERVICE_FILENAME)!!
+            val dateTime = intent.getStringExtra(SERVICE_DATETIME)!!
             val label = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 intent.getParcelableExtra(SERVICE_LABEL, Label::class.java)!!
             } else {
@@ -79,7 +80,7 @@ class FirebaseInsertService : Service() {
                             latitude = location?.latitude,
                             longitude = location?.longitude,
                             description = description,
-                            datetime = LocalDateTime.now(ZoneId.of("UTC"))
+                            datetime = dateTime
                         )
                     )
 
@@ -110,5 +111,6 @@ class FirebaseInsertService : Service() {
         const val SERVICE_LABEL = "service_label"
         const val SERVICE_LOCATION = "service_location"
         const val SERVICE_DESCRIPTION = "service_location"
+        const val SERVICE_DATETIME = "service_datetime"
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -143,7 +143,7 @@ class SynchronizationWorker @AssistedInject constructor(
 
             val photoDetail = async {
                 val photos = fireBaseRepository.getPhotos(uid)
-                val allLocalPhotos = roomRepository.getUnSynchronizedPhotoDetails()
+                val allLocalPhotos = roomRepository.getSyncCheckPhotos()
 
                 val unSynchronizedPhotoDetailsToServer = allLocalPhotos.filter { photo ->
                     photos.none { firebasePhoto ->

--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -196,7 +196,8 @@ class SynchronizationWorker @AssistedInject constructor(
                 labelName = label.labelName,
                 labelData = FirebaseLabel(
                     backgroundColor = label.labelBackgroundColor,
-                    thumbnailUri = storageUri.toString()
+                    thumbnailUri = storageUri.toString(),
+                    fileName = label.fileName
                 )
             )
     }

--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -1,6 +1,10 @@
 package com.and04.naturealbum.background.workmanager
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
@@ -31,9 +35,14 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
@@ -97,6 +106,10 @@ class SynchronizationWorker @AssistedInject constructor(
         try {
             val currentUser = Firebase.auth.currentUser ?: return@coroutineScope Result.failure()
             val uid = currentUser.uid
+            val unSynchronizedPhotoDetailsToLocal: MutableList<FirebasePhotoInfoResponse> =
+                mutableListOf()
+            val fileNameToLabelUid =
+                HashMap<String, Pair<Int, String>>()// key LabelName, value (label_id to labelName)
 
             val label = async {
                 val labels = fireBaseRepository.getLabels(uid)
@@ -108,13 +121,13 @@ class SynchronizationWorker @AssistedInject constructor(
                         firebaseLabel.labelName == label.labelName
                     }
                 }
+
                 // 로컬에 없는 서버 데이터
                 val unSynchronizedLabelsToLocal = labels.filter { label ->
                     allLocalLabels.none { localLabel ->
                         localLabel.labelName == label.labelName
                     }
                 }
-
 
                 // 로컬 > 서버
                 unSynchronizedLabelsToServer.forEach { label ->
@@ -126,7 +139,8 @@ class SynchronizationWorker @AssistedInject constructor(
                 // 서버 > 로컬
                 unSynchronizedLabelsToLocal.forEach { label ->
                     launch {
-                        insertLabelToLocal(label)
+                        fileNameToLabelUid[label.labelName] =
+                            insertLabelToLocal(label) to label.fileName
                     }
                 }
             }
@@ -148,29 +162,27 @@ class SynchronizationWorker @AssistedInject constructor(
                     }
                 }
 
-//                unSynchronizedPhotoDetailsToLocal = photos.filter { photo ->
-//                    allLocalPhotos.none { localPhoto ->
-//                        localPhoto.fileName == photo.fileName
-//                    }
-//                }
+                unSynchronizedPhotoDetailsToLocal.addAll(
+                    photos.filter { photo ->
+                        allLocalPhotos.none { localPhoto ->
+                            localPhoto.fileName == photo.fileName
+                        }
+                    }
+                )
             }
 
             label.await()
             photoDetail.await()
 
             // 서버 > 로컬
-//            unSynchronizedPhotoDetailsToLocal?.forEach { photo ->
-//                launch {
-//                    insertPhotoDetailToLocal(photo)
-//                }
-//            }
-//            insertLocalAlbum()
-//            roomRepository.insertPhotoInAlbum(
-//                Album(
-//                    labelId = labelId,
-//                    photoDetailId = photoDetailId.await().toInt()
-//                )
-//            )
+            val saveJob = async {
+                unSynchronizedPhotoDetailsToLocal.forEach { photo ->
+                    launch {
+                        insertPhotoDetailAndAlbumToLocal(photo, fileNameToLabelUid)
+                    }
+                }
+            }
+            saveJob.await()
 
             Result.success()
         } catch (e: Exception) {
@@ -202,15 +214,37 @@ class SynchronizationWorker @AssistedInject constructor(
             )
     }
 
-    private suspend fun insertLabelToLocal(label: FirebaseLabelResponse) =
+    private suspend fun insertLabelToLocal(label: FirebaseLabelResponse): Int =
         withContext(Dispatchers.IO + SupervisorJob()) {
             val localLabelData = Label(
                 backgroundColor = label.backgroundColor,
                 name = label.labelName
             )
 
-            roomRepository.insertLabel(localLabelData)
+            roomRepository.insertLabel(localLabelData).toInt()
         }
+
+    private suspend fun insertPhotoDetailAndAlbumToLocal(
+        photo: FirebasePhotoInfoResponse,
+        fileNameToLabelUid: HashMap<String, Pair<Int, String>>
+    ) = withContext(Dispatchers.IO + SupervisorJob()) {
+        // 라벨 대표 이미지에 대한 처리
+        val valueList = fileNameToLabelUid.values.toList()
+        val findAlbumData = valueList.find { value -> value.second == photo.fileName }
+        val uri = makeFileToUri(photo.uri, photo.fileName)
+
+        if (findAlbumData != null) {
+            // 사진 상세 추가
+            val labelId = findAlbumData.first
+            val photoDetailId = insertPhotoDetailToLocal(photo, labelId, uri)
+
+            insertAlbum(labelId, photoDetailId)
+        } else {
+            val labelId =
+                fileNameToLabelUid[photo.label]?.first ?: roomRepository.getIdByName(photo.label)!!
+            insertPhotoDetailToLocal(photo, labelId, uri)
+        }
+    }
 
     private suspend fun insertPhotoDetail(uid: String, photo: SyncPhotoDetailsDto) {
         val storageUri = fireBaseRepository
@@ -236,20 +270,60 @@ class SynchronizationWorker @AssistedInject constructor(
             )
     }
 
-//    private suspend fun insertPhotoDetailToLocal(photo: FirebasePhotoInfoResponse) =
-//        withContext(Dispatchers.IO + SupervisorJob()) {
-//            val photoDetailId = async {
-//                roomRepository.insertPhoto(
-//                    PhotoDetail(
-//                        labelId = labelId,
-//                        photoUri = uri,
-//                        fileName = fileName,
-//                        latitude = location.latitude,
-//                        longitude = location.longitude,
-//                        description = description,
-//                        datetime = time,
-//                    )
-//                )
-//            }
-//        }
+    private suspend fun insertPhotoDetailToLocal(
+        photo: FirebasePhotoInfoResponse,
+        labelId: Int,
+        uri: String
+    ): Int {
+        return roomRepository.insertPhoto(
+            PhotoDetail(
+                labelId = labelId,
+                photoUri = uri,
+                fileName = photo.fileName,
+                latitude = photo.latitude ?: 0.0, //FIXME 위치 NULL 해결 되면 삭제
+                longitude = photo.longitude ?: 0.0,
+                description = photo.description,
+                datetime = LocalDateTime
+                    .parse(photo.datetime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    .atZone(ZoneId.of("UTC"))
+                    .withZoneSameInstant(ZoneId.systemDefault())
+                    .toLocalDateTime(),
+            )
+        ).toInt()
+    }
+
+    private suspend fun insertAlbum(labelId: Int, photoDetailId: Int) {
+        roomRepository.insertPhotoInAlbum(
+            Album(
+                labelId = labelId,
+                photoDetailId = photoDetailId
+            )
+        )
+    }
+
+    private fun makeFileToUri(photoUri: String, fileName: String): String {
+        val context = applicationContext
+        val storage = context.filesDir
+        val imageFile = File(storage, fileName)
+        imageFile.createNewFile()
+
+        FileOutputStream(imageFile).use { fos ->
+            BitmapFactory.decodeStream(URL(photoUri).openStream()).apply {
+                if (Build.VERSION.SDK_INT >= 30) {
+                    compress(Bitmap.CompressFormat.WEBP_LOSSY, 100, fos)
+                } else {
+                    compress(Bitmap.CompressFormat.JPEG, 100, fos)
+                }
+
+                recycle()
+            }
+            fos.flush()
+        }
+
+        return FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            imageFile
+        ).toString()
+    }
 }

--- a/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
@@ -5,6 +5,12 @@ data class FirebaseLabel(
     val thumbnailUri: String
 )
 
+data class FirebaseLabelResponse(
+    val labelName: String = "",
+    val backgroundColor: String = "",
+    val thumbnailUri: String = ""
+)
+
 data class FirebasePhotoInfo(
     val uri: String,
     val label: String,
@@ -12,4 +18,14 @@ data class FirebasePhotoInfo(
     val longitude: Double?,
     val description: String,
     val datetime: String
+)
+
+data class FirebasePhotoInfoResponse(
+    val fileName: String = "",
+    val uri: String = "",
+    val label: String = "",
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val description: String = "",
+    val datetime: String = ""
 )

--- a/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
@@ -1,7 +1,5 @@
 package com.and04.naturealbum.data.dto
 
-import java.time.LocalDateTime
-
 data class FirebaseLabel(
     val backgroundColor: String,
     val thumbnailUri: String
@@ -13,5 +11,5 @@ data class FirebasePhotoInfo(
     val latitude: Double?,
     val longitude: Double?,
     val description: String,
-    val datetime: LocalDateTime
+    val datetime: String
 )

--- a/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/dto/FirebaseDto.kt
@@ -2,13 +2,15 @@ package com.and04.naturealbum.data.dto
 
 data class FirebaseLabel(
     val backgroundColor: String,
-    val thumbnailUri: String
+    val thumbnailUri: String,
+    val fileName: String
 )
 
 data class FirebaseLabelResponse(
     val labelName: String = "",
     val backgroundColor: String = "",
-    val thumbnailUri: String = ""
+    val thumbnailUri: String = "",
+    val fileName: String = ""
 )
 
 data class FirebasePhotoInfo(

--- a/app/src/main/java/com/and04/naturealbum/data/dto/RoomDataDto.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/dto/RoomDataDto.kt
@@ -9,7 +9,7 @@ data class AlbumDto(
     val photoDetailUri: String
 )
 
-data class UnSynchronizedAlbumsDto(
+data class SyncAlbumsDto(
     val labelId: Int,
     val labelName: String,
     val labelBackgroundColor: String,
@@ -17,12 +17,12 @@ data class UnSynchronizedAlbumsDto(
     val fileName: String
 )
 
-data class UnSynchronizedPhotoDetailsDto(
+data class SyncPhotoDetailsDto(
     val photoDetailUri: String,
     val labelName: String,
     val fileName: String,
     val longitude: Double,
     val latitude: Double,
     val description: String,
-    val datetime: LocalDateTime
+    val datetime: String
 )

--- a/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
@@ -14,6 +14,7 @@ import javax.inject.Inject
 interface DataRepository {
     suspend fun getLabels(): List<Label>
     suspend fun getLabelById(id: Int): Label
+    suspend fun getIdByName(name: String): Int?
     suspend fun getAllPhotoDetail(): List<PhotoDetail>
     suspend fun getPhotoDetailById(id: Int): PhotoDetail
     suspend fun getPhotoDetailsUriByLabelId(labelId: Int): List<PhotoDetail>
@@ -38,6 +39,10 @@ class DataRepositoryImpl @Inject constructor(
 
     override suspend fun getLabelById(id: Int): Label {
         return labelDao.getLabelById(id)
+    }
+
+    override suspend fun getIdByName(name: String): Int? {
+        return labelDao.getIdByName(name)
     }
 
     override suspend fun insertLabel(label: Label): Long {

--- a/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
@@ -20,7 +20,7 @@ interface DataRepository {
     suspend fun getPhotoDetailsUriByLabelId(labelId: Int): List<PhotoDetail>
     suspend fun getAllAlbum(): List<AlbumDto>
     suspend fun getSyncCheckAlbums(): List<SyncAlbumsDto>
-    suspend fun getUnSynchronizedPhotoDetails(): List<SyncPhotoDetailsDto>
+    suspend fun getSyncCheckPhotos(): List<SyncPhotoDetailsDto>
     suspend fun getAlbumByLabelId(labelId: Int): List<Album>
     suspend fun insertPhoto(photoDetail: PhotoDetail): Long
     suspend fun insertPhotoInAlbum(album: Album): Long
@@ -81,8 +81,8 @@ class DataRepositoryImpl @Inject constructor(
         return albumDao.getSyncCheckAlbums()
     }
 
-    override suspend fun getUnSynchronizedPhotoDetails(): List<SyncPhotoDetailsDto> {
-        return albumDao.getUnSynchronizedPhotos()
+    override suspend fun getSyncCheckPhotos(): List<SyncPhotoDetailsDto> {
+        return albumDao.getSyncCheckPhotos()
     }
 
     override suspend fun updateAlbum(album: Album) {

--- a/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/DataRepository.kt
@@ -1,8 +1,8 @@
 package com.and04.naturealbum.data.repository
 
 import com.and04.naturealbum.data.dto.AlbumDto
-import com.and04.naturealbum.data.dto.UnSynchronizedAlbumsDto
-import com.and04.naturealbum.data.dto.UnSynchronizedPhotoDetailsDto
+import com.and04.naturealbum.data.dto.SyncAlbumsDto
+import com.and04.naturealbum.data.dto.SyncPhotoDetailsDto
 import com.and04.naturealbum.data.room.Album
 import com.and04.naturealbum.data.room.AlbumDao
 import com.and04.naturealbum.data.room.Label
@@ -18,8 +18,8 @@ interface DataRepository {
     suspend fun getPhotoDetailById(id: Int): PhotoDetail
     suspend fun getPhotoDetailsUriByLabelId(labelId: Int): List<PhotoDetail>
     suspend fun getAllAlbum(): List<AlbumDto>
-    suspend fun getUnSynchronizedAlbums(labels: List<String>): List<UnSynchronizedAlbumsDto>
-    suspend fun getUnSynchronizedPhotoDetails(fileNames: List<String>): List<UnSynchronizedPhotoDetailsDto>
+    suspend fun getSyncCheckAlbums(): List<SyncAlbumsDto>
+    suspend fun getUnSynchronizedPhotoDetails(): List<SyncPhotoDetailsDto>
     suspend fun getAlbumByLabelId(labelId: Int): List<Album>
     suspend fun insertPhoto(photoDetail: PhotoDetail): Long
     suspend fun insertPhotoInAlbum(album: Album): Long
@@ -72,12 +72,12 @@ class DataRepositoryImpl @Inject constructor(
         return albumDao.getAllAlbum()
     }
 
-    override suspend fun getUnSynchronizedAlbums(labels: List<String>): List<UnSynchronizedAlbumsDto> {
-        return albumDao.getUnSynchronizedAlbums(labels)
+    override suspend fun getSyncCheckAlbums(): List<SyncAlbumsDto> {
+        return albumDao.getSyncCheckAlbums()
     }
 
-    override suspend fun getUnSynchronizedPhotoDetails(fileNames: List<String>): List<UnSynchronizedPhotoDetailsDto> {
-        return albumDao.getUnSynchronizedPhotos(fileNames)
+    override suspend fun getUnSynchronizedPhotoDetails(): List<SyncPhotoDetailsDto> {
+        return albumDao.getUnSynchronizedPhotos()
     }
 
     override suspend fun updateAlbum(album: Album) {

--- a/app/src/main/java/com/and04/naturealbum/data/repository/FireBaseRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/FireBaseRepository.kt
@@ -2,7 +2,9 @@ package com.and04.naturealbum.data.repository
 
 import android.net.Uri
 import com.and04.naturealbum.data.dto.FirebaseLabel
+import com.and04.naturealbum.data.dto.FirebaseLabelResponse
 import com.and04.naturealbum.data.dto.FirebasePhotoInfo
+import com.and04.naturealbum.data.dto.FirebasePhotoInfoResponse
 import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
@@ -13,8 +15,8 @@ import javax.inject.Inject
 interface FireBaseRepository {
     //SELECT
     suspend fun getLabel(uid: String, label: String): Task<DocumentSnapshot>
-    suspend fun getLabels(uid: String): List<String>
-    suspend fun getPhotos(uid: String): List<String>
+    suspend fun getLabels(uid: String): List<FirebaseLabelResponse>
+    suspend fun getPhotos(uid: String): List<FirebasePhotoInfoResponse>
 
     //INSERT
     suspend fun saveImageFile(uid: String, label: String, fileName: String, uri: Uri): Uri
@@ -43,18 +45,26 @@ class FireBaseRepositoryImpl @Inject constructor(
         return fireStore.collection(USER).document(uid).collection(LABEL).document(label).get()
     }
 
-    override suspend fun getLabels(uid: String): List<String> {
+    override suspend fun getLabels(uid: String): List<FirebaseLabelResponse> {
 
         val querySnapshot = fireStore.collection(USER).document(uid).collection(LABEL).get().await()
 
-        return querySnapshot.documents.map { document -> document.id }
+        return querySnapshot.documents.mapNotNull { document ->
+            document.toObject(FirebaseLabelResponse::class.java)?.copy(
+                labelName = document.id
+            )
+        }
     }
 
-    override suspend fun getPhotos(uid: String): List<String> {
+    override suspend fun getPhotos(uid: String): List<FirebasePhotoInfoResponse> {
         val photosQuerySet =
             fireStore.collection(USER).document(uid).collection(PHOTOS).get().await()
 
-        return photosQuerySet.documents.map { document -> document.id }
+        return photosQuerySet.documents.mapNotNull { document ->
+            document.toObject(FirebasePhotoInfoResponse::class.java)?.copy(
+                fileName = document.id
+            )
+        }
     }
 
     override suspend fun saveImageFile(

--- a/app/src/main/java/com/and04/naturealbum/data/room/DataDao.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/room/DataDao.kt
@@ -85,7 +85,7 @@ interface AlbumDao {
         JOIN photo_detail ON label.id == photo_detail.label_id
     """
     )
-    suspend fun getUnSynchronizedPhotos(): List<SyncPhotoDetailsDto>
+    suspend fun getSyncCheckPhotos(): List<SyncPhotoDetailsDto>
 
     @Query("SELECT * FROM album")
     suspend fun getALLAlbum(): List<Album>

--- a/app/src/main/java/com/and04/naturealbum/data/room/DataDao.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/room/DataDao.kt
@@ -5,8 +5,8 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
 import com.and04.naturealbum.data.dto.AlbumDto
-import com.and04.naturealbum.data.dto.UnSynchronizedAlbumsDto
-import com.and04.naturealbum.data.dto.UnSynchronizedPhotoDetailsDto
+import com.and04.naturealbum.data.dto.SyncAlbumsDto
+import com.and04.naturealbum.data.dto.SyncPhotoDetailsDto
 
 @Dao
 interface LabelDao {
@@ -67,10 +67,9 @@ interface AlbumDao {
         FROM album
         JOIN label ON album.label_id = label.id
         JOIN photo_detail ON album.photo_detail_id = photo_detail.id
-        WHERE label.name NOT IN (:labels)
     """
     )
-    suspend fun getUnSynchronizedAlbums(labels: List<String>): List<UnSynchronizedAlbumsDto>
+    suspend fun getSyncCheckAlbums(): List<SyncAlbumsDto>
 
     @Query(
         """
@@ -84,10 +83,9 @@ interface AlbumDao {
             photo_detail.datetime As datetime
         FROM label
         JOIN photo_detail ON label.id == photo_detail.label_id
-        WHERE photo_detail.file_name NOT IN (:fileNames)
     """
     )
-    suspend fun getUnSynchronizedPhotos(fileNames: List<String>): List<UnSynchronizedPhotoDetailsDto>
+    suspend fun getUnSynchronizedPhotos(): List<SyncPhotoDetailsDto>
 
     @Query("SELECT * FROM album")
     suspend fun getALLAlbum(): List<Album>

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreen.kt
@@ -53,13 +53,14 @@ import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.and04.naturealbum.R
-import com.and04.naturealbum.data.room.Label
 import com.and04.naturealbum.background.service.FirebaseInsertService
+import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_DATETIME
 import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_DESCRIPTION
 import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_FILENAME
 import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_LABEL
 import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_LOCATION
 import com.and04.naturealbum.background.service.FirebaseInsertService.Companion.SERVICE_URI
+import com.and04.naturealbum.data.room.Label
 import com.and04.naturealbum.ui.component.BackgroundImage
 import com.and04.naturealbum.ui.component.RotatingImageLoading
 import com.and04.naturealbum.ui.theme.NatureAlbumTheme
@@ -69,6 +70,8 @@ import com.and04.naturealbum.utils.NetworkState.DISCONNECTED
 import com.and04.naturealbum.utils.isPortrait
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun SavePhotoScreen(
@@ -123,7 +126,7 @@ fun SavePhotoScreen(
     onNavigateToMyPage: () -> Unit,
     onLabelSelect: () -> Unit,
     onBack: () -> Unit,
-    savePhoto: (String, String, Label, Location, String, Boolean) -> Unit
+    savePhoto: (String, String, Label, Location, String, Boolean, LocalDateTime) -> Unit
 ) {
     Scaffold(
         topBar = { LocalContext.current.GetTopbar { onNavigateToMyPage() } },
@@ -319,16 +322,18 @@ fun insertFirebaseService(
     fileName: String,
     label: Label,
     location: Location,
-    description: String
+    description: String,
+    time: LocalDateTime
 ) {
     if (Firebase.auth.currentUser == null || NetworkState.getNetWorkCode() == DISCONNECTED) return
-
+    val newTime = time.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     val intent = Intent(context, FirebaseInsertService::class.java).apply {
         putExtra(SERVICE_URI, model.toString())
         putExtra(SERVICE_FILENAME, fileName)
         putExtra(SERVICE_LABEL, label)
         putExtra(SERVICE_LOCATION, location) //FIXME Location == null
         putExtra(SERVICE_DESCRIPTION, description)
+        putExtra(SERVICE_DATETIME, newTime)
     }
 
     context.startService(intent)
@@ -356,7 +361,7 @@ private fun ScreenPreview() {
             onNavigateToMyPage = { },
             onLabelSelect = { },
             onBack = { },
-            savePhoto = { _, _, _, _, _, _ -> },
+            savePhoto = { _, _, _, _, _, _, _ -> },
         )
     }
 }

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenLandscape.kt
@@ -25,6 +25,8 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Composable
 fun SavePhotoScreenLandscape(
@@ -40,7 +42,7 @@ fun SavePhotoScreenLandscape(
     photoSaveState: State<UiState>,
     onLabelSelect: () -> Unit,
     onBack: () -> Unit,
-    savePhoto: (String, String, Label, Location, String, Boolean) -> Unit
+    savePhoto: (String, String, Label, Location, String, Boolean, LocalDateTime) -> Unit
 ) {
     val context = LocalContext.current
     Row(
@@ -101,13 +103,15 @@ fun SavePhotoScreenLandscape(
                     imageVector = Icons.Outlined.Create,
                     stringRes = R.string.save_photo_screen_save,
                     onClick = {
+                        val time = LocalDateTime.now(ZoneId.of("UTC"))
                         savePhoto(
                             model.toString(),
                             fileName,
                             label!!,
                             location!!, // TODO : Null 처리 필요
                             rememberDescription.value,
-                            isRepresented.value
+                            isRepresented.value,
+                            time
                         )
 
                         insertFirebaseService(
@@ -116,7 +120,8 @@ fun SavePhotoScreenLandscape(
                             fileName = fileName,
                             label = label,
                             location = location,
-                            description = rememberDescription.value
+                            description = rememberDescription.value,
+                            time = time
                         )
                     })
             }

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoScreenPortrait.kt
@@ -25,6 +25,8 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.and04.naturealbum.R
 import com.and04.naturealbum.data.room.Label
+import java.time.LocalDateTime
+import java.time.ZoneId
 
 @Composable
 fun SavePhotoScreenPortrait(
@@ -40,7 +42,7 @@ fun SavePhotoScreenPortrait(
     photoSaveState: State<UiState>,
     onLabelSelect: () -> Unit,
     onBack: () -> Unit,
-    savePhoto: (String, String, Label, Location, String, Boolean) -> Unit
+    savePhoto: (String, String, Label, Location, String, Boolean, LocalDateTime) -> Unit
 ) {
     val context = LocalContext.current
     Column(
@@ -94,13 +96,15 @@ fun SavePhotoScreenPortrait(
                 imageVector = Icons.Outlined.Create,
                 stringRes = R.string.save_photo_screen_save,
                 onClick = {
+                    val time = LocalDateTime.now(ZoneId.of("UTC"))
                     savePhoto(
                         model.toString(),
                         fileName,
                         label!!,
                         location!!, // TODO : Null 처리 필요
                         rememberDescription.value,
-                        isRepresented.value
+                        isRepresented.value,
+                        time
                     )
 
                     insertFirebaseService(
@@ -109,7 +113,8 @@ fun SavePhotoScreenPortrait(
                         fileName = fileName,
                         label = label,
                         location = location,
-                        description = rememberDescription.value
+                        description = rememberDescription.value,
+                        time = time
                     )
                 })
         }

--- a/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/savephoto/SavePhotoViewModel.kt
@@ -39,6 +39,7 @@ class SavePhotoViewModel @Inject constructor(
         location: Location,
         description: String,
         isRepresented: Boolean,
+        time: LocalDateTime
     ) {
         _photoSaveState.value = UiState.Loading // 로딩 시작
 
@@ -58,7 +59,7 @@ class SavePhotoViewModel @Inject constructor(
                             latitude = location.latitude,
                             longitude = location.longitude,
                             description = description,
-                            datetime = LocalDateTime.now(ZoneId.of("UTC")),
+                            datetime = time,
                         )
                     )
                 }


### PR DESCRIPTION
## FireStore Label Document Field에 fileName 추가한 이유
- 서버에서 로컬로 동기화 할 때 대표이미지를 확인 할 비교 대상이 필요한데 기존에는 없어서 저장할 수가 없었다. (PhotoDetailId가 필요하기 때문)
- 따라서 비교할 수 있는 fileName을 Label에 추가하여 이를 통해 비교하여 동기화 진행

## 서버 DateTime Type 변경 이유
- 기존에는 LocalDateTime 객체를 저장했는데 이 때의 문제점은 안드로이드에서 해당 객체를 불러올 때 변환이 안되는 문제가 발생, 해결하려면 해당 Data Class를 따로 생성해줘야 하는데 불필요하기도 하고 기존 Local에는 변환하여 문자열로 저장되는 것을 확인하여 서버에도 변환하여 저장

---

## 동기화 로직
1. 서버와 로컬 데이터를 모두 불러온다.
2. 서로 필요한 데이터들을 필터링
3. 필터링을 기반으로 각 DB 저장소에 저장 진행