### PR TITLE
동기화 시간 저장 및 UI 표시

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,6 +152,9 @@ dependencies {
 
     //WorkManager
     implementation(libs.androidx.work.runtime.ktx)
+
+    //Preferences Datastore
+    implementation(libs.androidx.datastore.preferences)
 }
 
 kapt {

--- a/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/workmanager/SynchronizationWorker.kt
@@ -10,6 +10,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.and04.naturealbum.data.datastore.DataStoreManager
 import com.and04.naturealbum.data.dto.FirebaseLabel
 import com.and04.naturealbum.data.dto.FirebasePhotoInfo
 import com.and04.naturealbum.data.dto.UnSynchronizedAlbumsDto
@@ -26,6 +27,8 @@ import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
@@ -34,7 +37,8 @@ class SynchronizationWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val roomRepository: DataRepository,
-    private val fireBaseRepository: FireBaseRepository
+    private val fireBaseRepository: FireBaseRepository,
+    private val syncDataStore: DataStoreManager
 ) : CoroutineWorker(appContext, workerParams) {
 
     companion object {
@@ -116,6 +120,10 @@ class SynchronizationWorker @AssistedInject constructor(
             label.await()
             photoDetail.await()
 
+            syncDataStore.setSyncTime(
+                LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            )
             Result.success()
         } catch (e: Exception) {
             //TODO FireStore와 LocalDB 비교 후 같이면 Result.success() 다르면 retry()

--- a/app/src/main/java/com/and04/naturealbum/data/datastore/DataStoreManager.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/datastore/DataStoreManager.kt
@@ -1,0 +1,34 @@
+package com.and04.naturealbum.data.datastore
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.map
+
+class DataStoreManager(
+    private val context: Context
+) {
+    private val Context.dataStore by preferencesDataStore(name = SYNC_TIME)
+    val syncTime = context.dataStore.data.map { time ->
+        time[SYNC_TIME_KEY] ?: NEVER_SYNC
+    }
+
+    suspend fun setSyncTime(dateTime: String) {
+        context.dataStore.edit { store ->
+            store[SYNC_TIME_KEY] = dateTime
+        }
+    }
+
+    suspend fun clear() {
+        context.dataStore.edit { store ->
+            store.clear()
+        }
+    }
+
+    companion object {
+        private const val SYNC_TIME = "sync_time"
+        const val NEVER_SYNC = "이력 없음"
+        private val SYNC_TIME_KEY = stringPreferencesKey(SYNC_TIME)
+    }
+}

--- a/app/src/main/java/com/and04/naturealbum/di/DataStoreModule.kt
+++ b/app/src/main/java/com/and04/naturealbum/di/DataStoreModule.kt
@@ -1,0 +1,21 @@
+package com.and04.naturealbum.di
+
+import android.content.Context
+import com.and04.naturealbum.data.datastore.DataStoreManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+
+    @Provides
+    @Singleton
+    fun providerDataStoreManager(
+        @ApplicationContext context: Context
+    ) = DataStoreManager(context)
+}

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageScreen.kt
@@ -79,11 +79,13 @@ fun MyPageScreen(
 ) {
     val uiState = myPageViewModel.uiState.collectAsStateWithLifecycle()
     val myFriends = myPageViewModel.myFriend.collectAsStateWithLifecycle()
+    val recentSyncTime = myPageViewModel.recentSyncTime.collectAsStateWithLifecycle()
 
     MyPageScreen(
         navigateToHome = navigateToHome,
         uiState = uiState,
         myFriends = myFriends,
+        recentSyncTime = recentSyncTime,
         signInWithGoogle = myPageViewModel::signInWithGoogle
     )
 }
@@ -93,6 +95,7 @@ fun MyPageScreen(
     navigateToHome: () -> Unit,
     uiState: State<UiState>,
     myFriends: State<List<MyFriend>>,
+    recentSyncTime: State<String>,
     signInWithGoogle: (Context) -> Unit,
 ) {
     val snackBarHostState = remember { SnackbarHostState() }
@@ -118,6 +121,7 @@ fun MyPageScreen(
                 .fillMaxSize(),
             uiState = uiState,
             myFriends = myFriends,
+            recentSyncTime = recentSyncTime,
             signInWithGoogle = signInWithGoogle,
             snackBarHostState = snackBarHostState
         )
@@ -129,6 +133,7 @@ private fun MyPageContent(
     modifier: Modifier,
     uiState: State<UiState>,
     myFriends: State<List<MyFriend>>,
+    recentSyncTime: State<String>,
     signInWithGoogle: (Context) -> Unit,
     snackBarHostState: SnackbarHostState
 ) {
@@ -148,7 +153,8 @@ private fun MyPageContent(
                 UserProfileContent(
                     uri = photoUri,
                     email = email,
-                    snackBarHostState = snackBarHostState
+                    snackBarHostState = snackBarHostState,
+                    recentSyncTime = recentSyncTime
                 )
 
                 SocialContent(
@@ -169,7 +175,8 @@ private fun MyPageContent(
 private fun UserProfileContent(
     uri: Uri? = null,
     email: String? = null,
-    snackBarHostState: SnackbarHostState? = null
+    snackBarHostState: SnackbarHostState? = null,
+    recentSyncTime: State<String>? = null
 ) {
     UserProfileImage(
         uri = uri?.toString(),
@@ -189,7 +196,10 @@ private fun UserProfileContent(
             textAlign = TextAlign.Center
         )
         if (!email.isNullOrBlank()) {
-            SyncContent(snackBarHostState = snackBarHostState!!)
+            SyncContent(
+                snackBarHostState = snackBarHostState!!,
+                recentSyncTime = recentSyncTime!!
+            )
         }
     }
 }
@@ -293,7 +303,8 @@ private fun MyPageCustomTab(tabState: Int, index: Int, title: String, onClick: (
 
 @Composable
 private fun SyncContent(
-    snackBarHostState: SnackbarHostState
+    snackBarHostState: SnackbarHostState,
+    recentSyncTime: State<String>
 ) {
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -337,7 +348,7 @@ private fun SyncContent(
     }
     Text(
         style = MaterialTheme.typography.bodySmall,
-        text = stringResource(R.string.my_page_not_yet_sync)
+        text = recentSyncTime.value
     )
 
 }
@@ -375,12 +386,14 @@ private fun MyPageScreenPreview() {
             )
         )
     }
+    val recentSyncTime = remember { mutableStateOf("2024-01-01") }
 
     NatureAlbumTheme {
         MyPageScreen(
             navigateToHome = {},
             uiState = uiState,
             myFriends = myFriends,
+            recentSyncTime = recentSyncTime,
             signInWithGoogle = {}
         )
     }

--- a/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/and04/naturealbum/ui/mypage/MyPageViewModel.kt
@@ -3,24 +3,36 @@ package com.and04.naturealbum.ui.mypage
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.and04.naturealbum.data.datastore.DataStoreManager
+import com.and04.naturealbum.data.datastore.DataStoreManager.Companion.NEVER_SYNC
 import com.and04.naturealbum.data.dto.MyFriend
 import com.and04.naturealbum.ui.savephoto.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val authenticationManager: AuthenticationManager
+    private val authenticationManager: AuthenticationManager,
+    private val syncDataStore: DataStoreManager
 ) : ViewModel() {
     private val _uiState = MutableStateFlow<UiState>(setInitUiState())
     val uiState: StateFlow<UiState> = _uiState
 
     private val _myFriends = MutableStateFlow<List<MyFriend>>(emptyList())
     val myFriend: StateFlow<List<MyFriend>> = _myFriends
+
+    val recentSyncTime: StateFlow<String> = syncDataStore.syncTime.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = NEVER_SYNC
+    )
 
     fun signInWithGoogle(context: Context) {
         authenticationManager.signInWithGoogle(context).onEach { response ->

--- a/app/src/test/java/com/and04/naturealbum/ExampleUnitDataStoreManager.kt
+++ b/app/src/test/java/com/and04/naturealbum/ExampleUnitDataStoreManager.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.*
  *
  * See [testing documentation](http://d.android.com/tools/testing).
  */
-class ExampleUnitTest {
+class ExampleUnitDataStoreManager {
     @Test
     fun addition_isCorrect() {
         assertEquals(4, 2 + 2)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.2"
+datastorePreferences = "1.1.1"
 desugar_jdk_libs = "2.0.3"
 credentials = "1.5.0-beta01"
 exifinterface = "1.3.7"
@@ -36,6 +37,7 @@ workRuntimeKtx = "2.10.0"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref = "credentials" }
 androidx-credentials-play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "credentials" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltNavigationCompose" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }


### PR DESCRIPTION
Data Store 사용 이유
1. 서버에 저장
- 유저가 앱 데이터를 지울 경우 이전 동기화와 데이터가 달라진다.
- 데이터가 달라졌는데 동기화 이력이 남아있는 부분이 좀 이상하여 탈락

2. Room에 저장
- Room에 저장하면 데이터를 지울 때 이력 또한 같이 사라지기 때문에 적합해보이지만 동기화 이력 하나 저장하고자 RoomDB 버전을 올리기엔 비효율적인 것 같아 탈락

---

따라서 동기화 이력을 간단하게 저장하고 갖다 쓸 수 있도록 DataStore 선택

DataStore
앱 내부 저장소 중 하나이며, key-value 형식으로 간단한 데이터를 저장할 수 있다.   
<img src="https://github.com/user-attachments/assets/2f745583-b052-4251-92be-55b0112b34dc" width=600/>
