### PR TITLE
[Fix] 서버에 라벨 없이 사진 정보만 들어가는 오류 해결

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
+++ b/app/src/main/java/com/and04/naturealbum/background/service/FirebaseInsertService.kt
@@ -81,7 +81,12 @@ class FirebaseInsertService : Service() {
                         uri = uri.toUri()
                     )
 
-                if (label.id == NEW_LABEL) {
+                val serverLabels = fireBaseRepository.getLabels(uid)
+                val serverNoLabel = serverLabels.none{ serverLabel ->
+                    serverLabel.labelName == label.name
+                }
+
+                if (serverNoLabel) {
                     fireBaseRepository
                         .insertLabel(
                             uid = uid,


### PR DESCRIPTION
기존 로컬에 이미 있는 라벨을 등록할 시 서버에는 라벨 없이 사진 정보만 들어가는 오류 발견

서버에 라벨이 있으면 사진 정보만 저장하는 로직으로 변경