### PR TITLE
[Fix] 대표이미지 삭제시 서버 앨범 업데이트 오류

### DIFF
--- a/app/src/main/java/com/and04/naturealbum/data/datasource/FirebaseDataSource.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/datasource/FirebaseDataSource.kt
@@ -87,6 +87,14 @@ class FirebaseDataSource @Inject constructor(
         }
     }
 
+    suspend fun getPhotoInfo(uid: String, fileName: String): DocumentSnapshot {
+        return fireStore.collection(USER).document(uid)
+            .collection(PHOTOS)
+            .document(fileName)
+            .get()
+            .await()
+    }
+
     suspend fun setUserPhoto(
         uid: String,
         fileName: String,

--- a/app/src/main/java/com/and04/naturealbum/data/repository/firebase/AlbumRepository.kt
+++ b/app/src/main/java/com/and04/naturealbum/data/repository/firebase/AlbumRepository.kt
@@ -134,6 +134,24 @@ class AlbumRepositoryImpl @Inject constructor(
                                 val albums = localRepository.getAlbumByLabelId(label.id)
                                 if (albums.isEmpty()) {
                                     firebaseDataSource.deleteUserLabel(uid, label)
+                                } else {
+                                    val albumPresentFileName =
+                                        localRepository.getPhotoDetailById(albums[0].photoDetailId).fileName
+                                    val document =
+                                        firebaseDataSource.getPhotoInfo(uid, albumPresentFileName)
+                                    document.toObject(FirebasePhotoInfoResponse::class.java)
+                                        ?.let { photoInfo ->
+                                            firebaseDataSource.setUserLabel(
+                                                uid,
+                                                label.name,
+                                                FirebaseLabel(
+                                                    backgroundColor = label.backgroundColor,
+                                                    thumbnailUri = photoInfo.uri,
+                                                    fileName = document.id,
+                                                )
+                                            )
+                                        }
+
                                 }
                             }
 


### PR DESCRIPTION
사진 삭제시 로컬의 FileName에 해당하는 사진으로 서버의 앨범 데이터 수정